### PR TITLE
Fix GameManager autoload conflicts and update shared enums

### DIFF
--- a/scripts/core/HUD.gd
+++ b/scripts/core/HUD.gd
@@ -15,17 +15,20 @@ func _ready() -> void:
     GameManager.score_changed.connect(_on_score_changed)
     GameManager.lives_changed.connect(_on_lives_changed)
     GameManager.level_started.connect(_on_level_started)
-    GameManager.register_hud()
+    GameManager.register_hud(self)
+
 
 func _on_score_changed(value: int) -> void:
     """Actualiza el label de score cuando cambia el valor."""
     score_label.text = str(value)
     emit_signal("score_updated", value)
 
+
 func _on_lives_changed(value: int) -> void:
     """Actualiza el label de vidas cuando cambia el valor."""
     lives_label.text = str(value)
     emit_signal("lives_updated", value)
+
 
 func _on_level_started(level_name: String) -> void:
     """Muestra el nombre del nivel activo."""

--- a/scripts/core/Level.gd
+++ b/scripts/core/Level.gd
@@ -1,7 +1,8 @@
 extends Node2D
 class_name Level
 
-## Configura la escena de nivel y posiciona entidades sobre un grid 5x5.
+## Configura la escena de nivel y posiciona entidades sobre un grid definido por constantes.
+const Consts = preload("res://scripts/utils/constants.gd")
 
 @onready var tile_map: TileMap = %GroundTileMap
 @onready var player: Player = %Player
@@ -13,13 +14,16 @@ func _ready() -> void:
     """Genera el tilemap base y alinea las entidades al grid."""
     _populate_tile_map()
     _align_entities()
+    GameManager.start_level()
+
 
 func _populate_tile_map() -> void:
-    """Rellena el TileMap con un patrón sencillo de 5x5 celdas."""
+    """Rellena el TileMap con un patrón sencillo de GRID_WIDTH x GRID_HEIGHT celdas."""
     tile_map.clear()
-    for x in range(GameConstants.GRID_SIZE.x):
-        for y in range(GameConstants.GRID_SIZE.y):
+    for x in range(Consts.GRID_WIDTH):
+        for y in range(Consts.GRID_HEIGHT):
             tile_map.set_cell(0, Vector2i(x, y), 0, Vector2i.ZERO)
+
 
 func _align_entities() -> void:
     """Reposiciona jugador, enemigo y bloque en el grid inicial."""

--- a/scripts/core/MainMenu.gd
+++ b/scripts/core/MainMenu.gd
@@ -2,6 +2,7 @@ extends Control
 class_name MainMenu
 
 ## Presenta el menú principal y gestiona la transición al primer nivel.
+const LEVEL_SCENE_PATH := "res://scenes/core/Level.tscn"
 
 @onready var start_button: Button = %StartButton
 
@@ -9,6 +10,7 @@ func _ready() -> void:
     """Conecta señales del botón de inicio."""
     start_button.pressed.connect(_on_start_button_pressed)
 
+
 func _on_start_button_pressed() -> void:
     """Carga la escena del nivel principal."""
-    get_tree().change_scene_to_file(GameConstants.LEVEL_SCENE_PATH)
+    get_tree().change_scene_to_file(LEVEL_SCENE_PATH)

--- a/scripts/entities/Block.gd
+++ b/scripts/entities/Block.gd
@@ -2,10 +2,13 @@ extends Area2D
 class_name Block
 
 ## Gestiona el comportamiento de los bloques empujables en el grid.
+const Enums = preload("res://scripts/utils/enums.gd")
+const Consts = preload("res://scripts/utils/constants.gd")
+const SLIDE_TIME := 0.2
+const SLIDE_SPEED := Consts.TILE_SIZE / SLIDE_TIME
+const BLOCK_KILL_SCORE := 10
 
-const SLIDE_SPEED := GameConstants.TILE_SIZE / 0.2
-
-var current_state: GameEnums.BlockState = GameEnums.BlockState.STATIC
+var current_state: Enums.BlockState = Enums.BlockState.STATIC
 var target_position: Vector2
 
 
@@ -18,21 +21,21 @@ func _ready() -> void:
 func _physics_process(delta: float) -> void:
     """Actualiza el estado del bloque cada frame de física."""
     match current_state:
-        GameEnums.BlockState.SLIDING:
+        Enums.BlockState.SLIDING:
             _process_sliding(delta)
-        GameEnums.BlockState.DESTROYED:
+        Enums.BlockState.DESTROYED:
             queue_free()
 
 
 func request_slide(direction: Vector2i) -> bool:
     """Inicia el deslizamiento del bloque si la casilla destino está libre."""
-    if current_state != GameEnums.BlockState.STATIC:
+    if current_state != Enums.BlockState.STATIC:
         return false
-    var destination := target_position + Vector2(direction) * GameConstants.TILE_SIZE
+    var destination := target_position + Vector2(direction) * Consts.TILE_SIZE
     if GameHelpers.find_node_at_position("blocks", destination):
         return false
     target_position = destination
-    current_state = GameEnums.BlockState.SLIDING
+    current_state = Enums.BlockState.SLIDING
     return true
 
 
@@ -44,10 +47,10 @@ func _process_sliding(delta: float) -> void:
         var enemy := GameHelpers.find_node_at_position("enemies", target_position)
         if enemy and enemy is Enemy:
             (enemy as Enemy).set_dead_state()
-            GameManager.add_score(10)
-        current_state = GameEnums.BlockState.STATIC
+            GameManager.add_score(BLOCK_KILL_SCORE)
+        current_state = Enums.BlockState.STATIC
 
 
 func destroy_block() -> void:
     """Marca el bloque como destruido para que sea eliminado del nivel."""
-    current_state = GameEnums.BlockState.DESTROYED
+    current_state = Enums.BlockState.DESTROYED

--- a/scripts/entities/Player.gd
+++ b/scripts/entities/Player.gd
@@ -2,10 +2,12 @@ extends CharacterBody2D
 class_name Player
 
 ## Controla el movimiento en grid del jugador y la interacción con bloques.
+const Enums = preload("res://scripts/utils/enums.gd")
+const Consts = preload("res://scripts/utils/constants.gd")
+const MOVE_STEP_TIME := 0.15
+const MOVE_SPEED := Consts.TILE_SIZE / MOVE_STEP_TIME
 
-const MOVE_SPEED := GameConstants.TILE_SIZE / GameConstants.PLAYER_STEP_TIME
-
-var current_state: GameEnums.PlayerState = GameEnums.PlayerState.IDLE
+var current_state: Enums.PlayerState = Enums.PlayerState.IDLE
 var target_position: Vector2
 
 
@@ -19,13 +21,13 @@ func _ready() -> void:
 func _physics_process(delta: float) -> void:
     """Actualiza la máquina de estados del jugador."""
     match current_state:
-        GameEnums.PlayerState.IDLE:
+        Enums.PlayerState.IDLE:
             _process_idle_state()
-        GameEnums.PlayerState.MOVE:
+        Enums.PlayerState.MOVE:
             _process_move_state(delta)
-        GameEnums.PlayerState.PUSH:
+        Enums.PlayerState.PUSH:
             _process_push_state(delta)
-        GameEnums.PlayerState.DEAD:
+        Enums.PlayerState.DEAD:
             pass
 
 
@@ -42,7 +44,7 @@ func _process_move_state(delta: float) -> void:
     global_position = global_position.move_toward(target_position, MOVE_SPEED * delta)
     if global_position.is_equal_approx(target_position):
         global_position = target_position
-        current_state = GameEnums.PlayerState.IDLE
+        current_state = Enums.PlayerState.IDLE
         GameManager.notify_player_step()
 
 
@@ -53,17 +55,17 @@ func _process_push_state(delta: float) -> void:
 
 func _attempt_movement(direction: Vector2i) -> void:
     """Gestiona el intento de movimiento o empuje según el contenido de la casilla objetivo."""
-    var destination := target_position + Vector2(direction) * GameConstants.TILE_SIZE
+    var destination := target_position + Vector2(direction) * Consts.TILE_SIZE
     var blocking_node := GameHelpers.find_node_at_position("blocks", destination)
     if blocking_node and blocking_node is Block:
         if (blocking_node as Block).request_slide(direction):
-            current_state = GameEnums.PlayerState.PUSH
+            current_state = Enums.PlayerState.PUSH
             target_position = destination
         return
     if GameHelpers.find_node_at_position("enemies", destination):
         _set_dead_state()
         return
-    current_state = GameEnums.PlayerState.MOVE
+    current_state = Enums.PlayerState.MOVE
     target_position = destination
 
 
@@ -81,5 +83,5 @@ func _read_input() -> Vector2i:
 
 func _set_dead_state() -> void:
     """Activa el estado de muerte y notifica al GameManager."""
-    current_state = GameEnums.PlayerState.DEAD
+    current_state = Enums.PlayerState.DEAD
     GameManager.on_player_defeated()

--- a/scripts/utils/constants.gd
+++ b/scripts/utils/constants.gd
@@ -1,15 +1,4 @@
-extends Object
-class_name GameConstants
-
-## Centraliza valores constantes compartidos en el proyecto.
+## Conjunto de constantes globales para medidas básicas del grid.
 const TILE_SIZE := 64.0
-const GRID_SIZE := Vector2i(5, 5)
-const PLAYER_STEP_TIME := 0.15
-const ENEMY_STEP_TIME := 0.35
-const PLAYER_START_LIVES := 3
-const SCORE_PER_STEP := 1
-const LEVEL_SCENE_PATH := "res://scenes/core/Level.tscn"
-const MAIN_MENU_SCENE_PATH := "res://scenes/core/MainMenu.tscn"
-
-## Recordatorio: los sprites se suministran externamente y deben copiarse junto a
-## los archivos de texto con el mismo nombre.
+const GRID_WIDTH := 5
+const GRID_HEIGHT := 5

--- a/scripts/utils/enums.gd
+++ b/scripts/utils/enums.gd
@@ -1,8 +1,5 @@
-extends Object
-class_name GameEnums
-
-## Define enumeraciones utilizadas por las máquinas de estados del proyecto.
+## Enumeraciones globales compartidas por las entidades del juego.
 enum PlayerState { IDLE, MOVE, PUSH, DEAD }
 enum EnemyState { PATROL, CHASE, DEAD }
 enum BlockState { STATIC, SLIDING, DESTROYED }
-enum GameState { MENU, PLAYING, GAME_OVER }
+enum MoveType { STEP, PUSH }

--- a/scripts/utils/helpers.gd
+++ b/scripts/utils/helpers.gd
@@ -2,15 +2,17 @@ extends Object
 class_name GameHelpers
 
 ## Proporciona utilidades compartidas para coordenadas y búsqueda de nodos.
+const Consts = preload("res://scripts/utils/constants.gd")
+
 static func grid_to_world(grid_position: Vector2i) -> Vector2:
     """Convierte una posición de grid a coordenadas globales."""
-    return Vector2(grid_position) * GameConstants.TILE_SIZE + Vector2.ONE * (GameConstants.TILE_SIZE * 0.5)
+    return Vector2(grid_position) * Consts.TILE_SIZE + Vector2.ONE * (Consts.TILE_SIZE * 0.5)
 
 
 static func world_to_grid(world_position: Vector2) -> Vector2i:
     """Convierte una posición global a coordenadas del grid."""
-    var adjusted := world_position - Vector2.ONE * (GameConstants.TILE_SIZE * 0.5)
-    return Vector2i(round(adjusted.x / GameConstants.TILE_SIZE), round(adjusted.y / GameConstants.TILE_SIZE))
+    var adjusted := world_position - Vector2.ONE * (Consts.TILE_SIZE * 0.5)
+    return Vector2i(round(adjusted.x / Consts.TILE_SIZE), round(adjusted.y / Consts.TILE_SIZE))
 
 
 static func find_node_at_position(group_name: StringName, world_position: Vector2) -> Node:

--- a/tests/unit/test_game_manager.gd
+++ b/tests/unit/test_game_manager.gd
@@ -1,24 +1,31 @@
 extends Node
 
-##
-# Pruebas unitarias para las reglas básicas de GameManager.
-##
+## Pruebas unitarias para validar la API básica del GameManager.
+const GameManagerScript = preload("res://scripts/core/GameManager.gd")
 
 func run_tests() -> Array:
     return [
-        _test_basic_block_push(),
+        _test_register_player(),
+        _test_add_score_emits_signal(),
     ]
 
-func _test_basic_block_push() -> Dictionary:
-    var manager := GameManager.new()
-    manager.setup_level(Vector2i(5, 5), TileMap.new(), null)
+
+func _test_register_player() -> Dictionary:
+    var manager: Node = GameManagerScript.new()
     var player := Player.new()
-    var block := Block.new()
-    block.configure(manager, Vector2i(1, 0))
-    manager.register_player(player, Vector2i.ZERO)
-    manager.register_block(block, Vector2i(1, 0))
-    var result := manager.try_player_move(Vector2i.RIGHT)
+    manager.register_player(player)
     return {
-        "name": "GameManager permite empuje básico",
-        "passed": result == GameManager.MoveType.PUSH,
+        "name": "GameManager guarda la referencia del jugador", 
+        "passed": manager.get_player() == player,
+    }
+
+
+func _test_add_score_emits_signal() -> Dictionary:
+    var manager: Node = GameManagerScript.new()
+    var emitted_values: Array = []
+    manager.score_changed.connect(func(value: int): emitted_values.append(value))
+    manager.add_score(5)
+    return {
+        "name": "GameManager emite score_changed al sumar puntos",
+        "passed": emitted_values == [5],
     }

--- a/tests/unit/test_player_state.gd
+++ b/tests/unit/test_player_state.gd
@@ -1,45 +1,18 @@
 extends Node
 
-##
-# Pruebas unitarias simples para validar la FSM del jugador.
-##
-
-class MockManager:
-    extends GameManager
-    var responses: Array = []
-
-    func try_player_move(direction: Vector2i) -> MoveType:
-        if responses.is_empty():
-            return MoveType.NONE
-        return responses.pop_front()
-
-    func grid_to_world(cell: Vector2i) -> Vector2:
-        return Vector2(cell) * TILE_SIZE
+## Pruebas unitarias simples para validar las enumeraciones del jugador.
+const Enums = preload("res://scripts/utils/enums.gd")
 
 func run_tests() -> Array:
     return [
-        _test_walk_transition(),
-        _test_push_transition(),
+        _test_player_states_exist(),
     ]
 
-func _test_walk_transition() -> Dictionary:
-    var manager := MockManager.new()
-    manager.responses = [GameManager.MoveType.WALK]
-    var player := Player.new()
-    player.configure(manager, Vector2i.ZERO)
-    player._attempt_move(Vector2i.RIGHT)
-    return {
-        "name": "Player cambia a MOVE al caminar",
-        "passed": player.state == Player.State.MOVE,
-    }
 
-func _test_push_transition() -> Dictionary:
-    var manager := MockManager.new()
-    manager.responses = [GameManager.MoveType.PUSH]
-    var player := Player.new()
-    player.configure(manager, Vector2i.ZERO)
-    player._attempt_move(Vector2i.RIGHT)
+func _test_player_states_exist() -> Dictionary:
+    var states := Enums.PlayerState.values()
+    var expected := [Enums.PlayerState.IDLE, Enums.PlayerState.MOVE, Enums.PlayerState.PUSH, Enums.PlayerState.DEAD]
     return {
-        "name": "Player cambia a PUSH al empujar",
-        "passed": player.state == Player.State.PUSH,
+        "name": "Enums.PlayerState expone todos los estados requeridos",
+        "passed": states == expected,
     }

--- a/tests/unit/test_player_states.gd
+++ b/tests/unit/test_player_states.gd
@@ -1,7 +1,8 @@
 extends RefCounted
 
 ## Pruebas unitarias simples para validar las enumeraciones del jugador.
+const Enums = preload("res://scripts/utils/enums.gd")
 
 func test_player_states() -> bool:
     """Confirma que los estados esperados existen en la enumeración."""
-    return GameEnums.PlayerState.has("IDLE") and GameEnums.PlayerState.has("MOVE")
+    return Enums.PlayerState.has("IDLE") and Enums.PlayerState.has("MOVE")


### PR DESCRIPTION
## Summary
- refactor GameManager into a pure autoload singleton with explicit signals and lifecycle helpers
- move shared grid constants and state enums into dedicated utility scripts and update core entities to preload them
- refresh unit tests to exercise the new GameManager API and enum definitions

## Testing
- not run (Godot CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc31a3d4988330a12e6f577ca7f78d