### PR TITLE
Add project-wide and scoped gitignore configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Godot project metadata
+.godot/
+.import/
+*.import
+*.uid
+
+# C# build artifacts
+bin/
+obj/
+.mono/
+
+# IDE/editor configuration
+.vscode/
+.idea/
+.vs/
+*.suo
+*.user
+*.userprefs
+
+# System and temporary files
+.DS_Store
+Thumbs.db
+*.log
+*.tmp
+~*

--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,0 +1,15 @@
+# Ignore source assets kept out of version control
+raw/
+
+# Large editable binaries
+*.psd
+*.psb
+*.xcf
+*.kra
+*.ai
+*.blend
+*.max
+*.mb
+*.ma
+
+# Allow finished game-ready assets by default (e.g. .png, .ogg, .wav, .ttf)

--- a/levels/.gitignore
+++ b/levels/.gitignore
@@ -1,0 +1,13 @@
+# Ignore everything by default to ensure only curated level data is tracked
+*
+
+# Allow directory structure
+!*/
+
+# Keep this ignore file and official JSON level definitions
+!.gitignore
+!*.json
+
+# Explicitly ignore common temporary files
+*.bak
+*.tmp

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,16 @@
+# Ignore generated snapshots and dumps
+*.snap
+*.snapshot
+*.dump
+*.tmp
+*.log
+
+# Coverage outputs
+coverage/
+coverage-*/
+*.coverage
+*.xml
+*.html
+
+# Keep only GDScript tests
+!*.gd


### PR DESCRIPTION
## Summary
- add a root-level `.gitignore` covering Godot metadata, C# build outputs, IDE configs, and temporary files
- scope `.gitignore` files for `assets`, `tests`, and `levels` to keep only the desired asset, testing, and level data artifacts in version control

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc418ed4e48330addca0ecc5e74b15