### PR TITLE
Fix scene change signal and HUD alignment

### DIFF
--- a/scripts/core/GameManager.gd
+++ b/scripts/core/GameManager.gd
@@ -20,7 +20,7 @@ var _enemies: Array[Enemy] = []
 
 func _ready() -> void:
     """Emite el estado inicial al arrancar el autoload."""
-    get_tree().connect("current_scene_changed", Callable(self, "_on_current_scene_changed"))
+    get_tree().connect("scene_changed", Callable(self, "_on_scene_changed"))
     score_changed.emit(_score)
     lives_changed.emit(_lives)
 
@@ -105,7 +105,7 @@ func notify_player_step() -> void:
     add_score(STEP_SCORE)
 
 
-func _on_current_scene_changed(new_scene: Node) -> void:
+func _on_scene_changed(new_scene: Node) -> void:
     """Detecta cambios de escena para iniciar niveles automáticamente."""
     if new_scene and new_scene.scene_file_path == LEVEL_SCENE_PATH:
         start_level()

--- a/scripts/core/Level.gd
+++ b/scripts/core/Level.gd
@@ -36,4 +36,4 @@ func _align_entities() -> void:
     block.target_position = block.global_position
     enemy.global_position = GameHelpers.grid_to_world(enemy_cell)
     enemy.target_position = enemy.global_position
-    hud.global_position = Vector2.ZERO
+    hud.offset = Vector2.ZERO


### PR DESCRIPTION
## Summary
- connect GameManager to the valid `scene_changed` signal to detect level transitions
- reset the HUD layer using its offset instead of assigning a nonexistent global position

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4846a56483308038d96f4c738db3