### PR TITLE
Implement JSON level loading and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
 - [x] Empuje de bloques
 - [x] IA básica de enemigos
 - [x] HUD y sistema de score
-- [ ] Niveles iniciales
+- [x] Niveles iniciales
 - [ ] Colisión de bloques con enemigos (enemigos aplastados)
 - [ ] Power-ups y sistema de bonus (frutas/ítems)
-- [ ] Niveles iniciales (carga desde JSON en /levels)
+- [x] Niveles iniciales (carga desde JSON en /levels)
 - [ ] Sistema de transición de niveles (pasar al siguiente al derrotar enemigos)
 - [ ] Sistema de Game Over y reinicio
 - [ ] Menú principal funcional

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -61,10 +61,11 @@ stateDiagram-v2
 ---
 
 ## Sistema de Juego (GameManager)
-- Cargar nivel  
-- Spawnear enemigos  
-- Controlar condiciones de victoria/derrota  
-- Gestionar score global y vidas  
+- Cargar nivel
+- Spawnear enemigos
+- Controlar condiciones de victoria/derrota
+- Registrar y desregistrar enemigos activos según el layout
+- Gestionar score global y vidas
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ Clonar en Godot el juego arcade *Don’t Pull* (Capcom, 1991 dentro de Three Won
   - Menú inicial y selección de nivel.
 - **Data Layer**
   - Carga de niveles desde JSON/TSV.
+  - `LevelLoader` convierte JSON en datos estructurados para la escena `Level`.
   - Configuración de enemigos y power-ups.
 - **Assets**
   - Spritesheets (placeholders o extraídos de ROM).
@@ -48,7 +49,7 @@ Clonar en Godot el juego arcade *Don’t Pull* (Capcom, 1991 dentro de Three Won
 
 ## Flujo principal del juego
 1. **Init →** carga escena `MainMenu`.
-2. **Level Start →** spawnea jugador, enemigos y bloques desde layout JSON.
+2. **Level Start →** `Level` solicita a `LevelLoader` el layout JSON y spawnea jugador, enemigos y bloques.
 3. **Gameplay Loop →**
    - Jugador mueve en grid.
    - Empuje de bloques → bloques deslizan hasta colisión.

--- a/levels/level_01.json
+++ b/levels/level_01.json
@@ -1,0 +1,13 @@
+{
+    "name": "Orchard-01",
+    "grid_size": {"width": 7, "height": 7},
+    "player": {"start": [1, 3]},
+    "blocks": [
+        [2, 3],
+        [4, 3]
+    ],
+    "enemies": [
+        {"type": "random", "start": [5, 3]},
+        {"type": "chaser", "start": [3, 5]}
+    ]
+}

--- a/scenes/core/Level.tscn
+++ b/scenes/core/Level.tscn
@@ -39,10 +39,16 @@ tile_set = SubResource("4")
 [node name="Player" parent="." instance=ExtResource("2")]
 unique_name_in_owner = true
 
-[node name="Enemy" parent="." instance=ExtResource("3")]
+[node name="Enemies" type="Node2D" parent="."]
 unique_name_in_owner = true
 
-[node name="Block" parent="." instance=ExtResource("4")]
+[node name="Enemy" parent="Enemies" instance=ExtResource("3")]
+unique_name_in_owner = true
+
+[node name="Blocks" type="Node2D" parent="."]
+unique_name_in_owner = true
+
+[node name="Block" parent="Blocks" instance=ExtResource("4")]
 unique_name_in_owner = true
 
 [node name="HUD" parent="." instance=ExtResource("5")]

--- a/scripts/core/GameManager.gd
+++ b/scripts/core/GameManager.gd
@@ -2,40 +2,33 @@
 extends Node
 
 const Consts = preload("res://scripts/utils/constants.gd")
-
 signal score_changed(new_score: int)
 signal lives_changed(new_lives: int)
 signal level_started(level_name: String)
 signal game_over()
-
 var _player: Player
 var _score := 0
 var _lives := Consts.START_LIVES
 var _enemies: Array[Enemy] = []
-
 func _ready() -> void:
     """Emite el estado inicial al arrancar el autoload."""
     get_tree().scene_changed.connect(_on_scene_changed)
     score_changed.emit(_score)
     lives_changed.emit(_lives)
 
-
 func register_player(player: Player) -> void:
     """Guarda la referencia del jugador activo."""
     _player = player
-
 
 func register_hud(_hud: HUD) -> void:
     """Asocia el HUD activo y le envía el estado global."""
     score_changed.emit(_score)
     lives_changed.emit(_lives)
 
-
 func add_score(value: int) -> void:
     """Incrementa el score global y notifica el cambio."""
     _score += value
     score_changed.emit(_score)
-
 
 func set_lives(value: int) -> void:
     """Actualiza las vidas del jugador y dispara la señal correspondiente."""
@@ -44,24 +37,24 @@ func set_lives(value: int) -> void:
     if _lives <= 0:
         game_over.emit()
 
-
 func start_level() -> void:
     """Propaga el inicio del nivel actual al HUD."""
     var current_scene := get_tree().current_scene
     level_started.emit(current_scene.name if current_scene else "")
-
 
 func register_enemy(enemy: Enemy) -> void:
     """Añade enemigos activos para referencia rápida."""
     if enemy not in _enemies:
         _enemies.append(enemy)
 
+func unregister_enemy(enemy: Enemy) -> void:
+    """Elimina un enemigo del registro sin otorgar puntuación."""
+    _enemies.erase(enemy)
 
 func on_enemy_defeated(enemy: Enemy) -> void:
     """Elimina la referencia del enemigo y suma score."""
     _enemies.erase(enemy)
     add_score(Consts.ENEMY_SCORE)
-
 
 func on_player_defeated() -> void:
     """Reduce las vidas del jugador y gestiona el reinicio o fin de partida."""
@@ -71,12 +64,10 @@ func on_player_defeated() -> void:
     else:
         return_to_menu()
 
-
 func restart_level() -> void:
     """Recarga el nivel actual si existe."""
     if get_tree().current_scene and get_tree().current_scene.scene_file_path == Consts.LEVEL_SCENE_PATH:
         get_tree().reload_current_scene()
-
 
 func return_to_menu() -> void:
     """Regresa al menú principal y restablece score y vidas."""
@@ -86,16 +77,13 @@ func return_to_menu() -> void:
     lives_changed.emit(_lives)
     get_tree().change_scene_to_file(Consts.MAIN_MENU_SCENE_PATH)
 
-
 func get_player() -> Player:
     """Devuelve el jugador registrado."""
     return _player
 
-
 func notify_player_step() -> void:
     """Suma score por cada paso válido del jugador."""
     add_score(Consts.STEP_SCORE)
-
 
 func _on_scene_changed(new_scene: Node) -> void:
     """Detecta cambios de escena para iniciar niveles automáticamente."""

--- a/scripts/core/Level.gd
+++ b/scripts/core/Level.gd
@@ -1,37 +1,101 @@
-## Level configura la escena de juego y posiciona entidades sobre un grid común.
+## Level configura la escena de juego cargando datos desde JSON y posiciona entidades en el grid.
 extends Node2D
 class_name Level
 
 const Consts = preload("res://scripts/utils/constants.gd")
 const GameHelpers = preload("res://scripts/utils/helpers.gd")
-
+const LevelLoader = preload("res://scripts/utils/level_loader.gd")
+const EnemyScene: PackedScene = preload("res://scenes/entities/Enemy.tscn")
+const BlockScene: PackedScene = preload("res://scenes/entities/Block.tscn")
+@export var level_file: String = ""
 @onready var tile_map: TileMap = %GroundTileMap
 @onready var player: Player = %Player
-@onready var enemy: Enemy = %Enemy
-@onready var block: Block = %Block
+@onready var enemy_container: Node2D = %Enemies
+@onready var block_container: Node2D = %Blocks
 @onready var hud: HUD = %HUD
-
 func _ready() -> void:
-    """Genera el tilemap base y alinea las entidades al grid."""
-    _populate_tile_map()
-    _align_entities()
+    """Carga los datos del nivel y posiciona entidades según el layout."""
+    _apply_level_data(_load_level_data())
     GameManager.start_level()
 
 
-func _populate_tile_map() -> void:
-    """Rellena el TileMap con un patrón sencillo de GRID_WIDTH x GRID_HEIGHT celdas."""
+func _load_level_data() -> Dictionary:
+    var path := level_file if level_file != "" else LevelLoader.get_default_level_path()
+    var data := LevelLoader.load_level(path)
+    if not data.is_empty():
+        return data
+    return {
+        "grid_size": {"width": Consts.GRID_WIDTH, "height": Consts.GRID_HEIGHT},
+        "player": {"start": Consts.PLAYER_START},
+        "blocks": [Consts.BLOCK_START],
+        "enemies": [Consts.ENEMY_START],
+    }
+
+func _apply_level_data(data: Dictionary) -> void:
+    var grid_size := data.get("grid_size", {})
+    var width := int(grid_size.get("width", Consts.GRID_WIDTH))
+    var height := int(grid_size.get("height", Consts.GRID_HEIGHT))
+    _populate_tile_map(width, height)
+    _position_player(data.get("player", {}))
+    _spawn_blocks(data.get("blocks", []))
+    _spawn_enemies(data.get("enemies", []))
+    hud.offset = Vector2.ZERO
+
+func _populate_tile_map(width: int, height: int) -> void:
     tile_map.clear()
-    for x in range(Consts.GRID_WIDTH):
-        for y in range(Consts.GRID_HEIGHT):
+    for x in range(width):
+        for y in range(height):
             tile_map.set_cell(0, Vector2i(x, y), 0, Vector2i.ZERO)
 
-
-func _align_entities() -> void:
-    """Reposiciona jugador, enemigo y bloque en el grid inicial."""
-    player.global_position = GameHelpers.grid_to_world(Consts.PLAYER_START)
+func _position_player(player_data: Dictionary) -> void:
+    var start := _extract_position(player_data.get("start", player_data), Consts.PLAYER_START)
+    player.global_position = GameHelpers.grid_to_world(start)
     player.target_position = player.global_position
-    block.global_position = GameHelpers.grid_to_world(Consts.BLOCK_START)
-    block.target_position = block.global_position
-    enemy.global_position = GameHelpers.grid_to_world(Consts.ENEMY_START)
-    enemy.target_position = enemy.global_position
-    hud.offset = Vector2.ZERO
+
+func _spawn_blocks(positions: Array) -> void:
+    _clear_container(block_container)
+    if positions.is_empty():
+        _spawn_block(Consts.BLOCK_START)
+        return
+    for entry in positions:
+        _spawn_block(_extract_position(entry, Consts.BLOCK_START))
+
+func _spawn_enemies(positions: Array) -> void:
+    _clear_container(enemy_container)
+    if positions.is_empty():
+        _spawn_enemy(Consts.ENEMY_START)
+        return
+    for entry in positions:
+        _spawn_enemy(_extract_position(entry, Consts.ENEMY_START))
+
+func _spawn_block(grid_position: Vector2i) -> void:
+    var block_instance: Block = BlockScene.instantiate()
+    block_instance.global_position = GameHelpers.grid_to_world(grid_position)
+    block_container.add_child(block_instance)
+    block_instance.target_position = block_instance.global_position
+
+func _spawn_enemy(grid_position: Vector2i) -> void:
+    var enemy_instance: Enemy = EnemyScene.instantiate()
+    enemy_instance.global_position = GameHelpers.grid_to_world(grid_position)
+    enemy_container.add_child(enemy_instance)
+    enemy_instance.target_position = enemy_instance.global_position
+
+func _clear_container(container: Node) -> void:
+    for child in container.get_children():
+        if child is Enemy:
+            GameManager.unregister_enemy(child)
+        child.queue_free()
+
+func _extract_position(value, fallback: Vector2i) -> Vector2i:
+    if value is Dictionary:
+        if value.has("start"):
+            return _extract_position(value["start"], fallback)
+        if value.has("position"):
+            return _extract_position(value["position"], fallback)
+    if value is Array and value.size() >= 2:
+        return Vector2i(int(value[0]), int(value[1]))
+    if value is Vector2i:
+        return value
+    if value is Vector2:
+        return Vector2i(int(value.x), int(value.y))
+    return fallback

--- a/scripts/utils/constants.gd
+++ b/scripts/utils/constants.gd
@@ -16,3 +16,5 @@ const ENEMY_CHASE_RANGE := 2
 const CARDINAL_DIRECTIONS := [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
 const LEVEL_SCENE_PATH := "res://scenes/core/Level.tscn"
 const MAIN_MENU_SCENE_PATH := "res://scenes/core/MainMenu.tscn"
+const LEVELS_DIR := "res://levels/"
+const DEFAULT_LEVEL_FILE := "level_01.json"

--- a/scripts/utils/level_loader.gd
+++ b/scripts/utils/level_loader.gd
@@ -1,0 +1,37 @@
+## LevelLoader ofrece utilidades para cargar descripciones de niveles desde JSON.
+extends Object
+class_name LevelLoader
+
+const Consts = preload("res://scripts/utils/constants.gd")
+
+static func get_default_level_path() -> String:
+    """Devuelve la ruta completa del nivel por defecto."""
+    return Consts.LEVELS_DIR + Consts.DEFAULT_LEVEL_FILE
+
+
+static func load_level(path: String) -> Dictionary:
+    """Carga un archivo JSON de nivel y devuelve su contenido como diccionario."""
+    var resolved_path := _resolve_path(path)
+    if resolved_path == "":
+        return {}
+    if not FileAccess.file_exists(resolved_path):
+        push_warning("Nivel no encontrado: %s" % resolved_path)
+        return {}
+    var file := FileAccess.open(resolved_path, FileAccess.READ)
+    if file == null:
+        push_warning("No se pudo abrir el archivo de nivel: %s" % resolved_path)
+        return {}
+    var json := JSON.new()
+    var parse_error := json.parse(file.get_as_text())
+    if parse_error != OK:
+        push_warning("Error al parsear nivel %s: %s" % [resolved_path, json.get_error_message()])
+        return {}
+    return json.data if json.data is Dictionary else {}
+
+
+static func _resolve_path(path: String) -> String:
+    if path == "":
+        return ""
+    if path.begins_with("res://"):
+        return path
+    return Consts.LEVELS_DIR + path

--- a/tests/integration/LevelSandbox.tscn
+++ b/tests/integration/LevelSandbox.tscn
@@ -1,7 +1,8 @@
 [gd_scene load_steps=2 format=3]
 
-[ext_resource type="PackedScene" path="res://scenes/Level.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/core/Level.tscn" id="1"]
 
 [node name="LevelSandbox" type="Node"]
 
 [node name="Level" parent="LevelSandbox" instance=ExtResource("1")]
+level_file = "res://levels/level_01.json"

--- a/tests/unit/test_level_loader.gd
+++ b/tests/unit/test_level_loader.gd
@@ -1,0 +1,38 @@
+## TestLevelLoader valida la carga de archivos JSON de nivel.
+extends Node
+
+const LevelLoader = preload("res://scripts/utils/level_loader.gd")
+
+func run_tests() -> Array:
+    """Ejecuta los casos asociados al LevelLoader."""
+    return [
+        _test_load_default_level(),
+        _test_missing_level_returns_empty(),
+        _test_relative_path_resolution(),
+    ]
+
+
+func _test_load_default_level() -> Dictionary:
+    var data := LevelLoader.load_level(LevelLoader.get_default_level_path())
+    var player_data := data.get("player", {})
+    var start := player_data.get("start", [])
+    return {
+        "name": "LevelLoader carga el nivel por defecto",
+        "passed": data.get("name", "") == "Orchard-01" and start.size() == 2,
+    }
+
+
+func _test_missing_level_returns_empty() -> Dictionary:
+    var data := LevelLoader.load_level("res://levels/unknown_level.json")
+    return {
+        "name": "LevelLoader devuelve diccionario vacío si falta el archivo",
+        "passed": data.is_empty(),
+    }
+
+
+func _test_relative_path_resolution() -> Dictionary:
+    var data := LevelLoader.load_level("level_01.json")
+    return {
+        "name": "LevelLoader resuelve rutas relativas al directorio de niveles",
+        "passed": data.get("name", "") == "Orchard-01",
+    }


### PR DESCRIPTION
## Summary
- load the Level scene layout from JSON using a new LevelLoader utility and dynamic block/enemy instancing
- add a default level description, mark roadmap progress, and document the LevelLoader dependency
- provide unit and integration assets covering the JSON loading behaviour

## Testing
- not run (Godot CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dc6f7dc1e08330a379f3b13487a05f