### PR TITLE
Add collectible power-up bonus system

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
 - [x] HUD y sistema de score
 - [x] Niveles iniciales
 - [x] Colisión de bloques con enemigos (enemigos aplastados)
-- [ ] Power-ups y sistema de bonus (frutas/ítems)
+- [x] Power-ups y sistema de bonus (frutas/ítems)
 - [x] Niveles iniciales (carga desde JSON en /levels) — warnings de tipado corregidos en Level.gd
 - [ ] Colisión jugador/bloque: **el jugador nunca debe quedar debajo de un bloque** (bloques siempre se priorizan sobre el jugador al empujar/colisionar).
 - [ ] Límites del mapa: agregar **bordes sólidos** que no puedan cruzarse (ni jugador, ni bloques, ni enemigos).

--- a/levels/level_01.json
+++ b/levels/level_01.json
@@ -9,5 +9,9 @@
     "enemies": [
         {"type": "random", "start": [5, 3]},
         {"type": "chaser", "start": [3, 5]}
+    ],
+    "power_ups": [
+        {"type": "fruit", "position": [3, 1]},
+        {"type": "gem", "position": [5, 5], "score": 250}
     ]
 }

--- a/scenes/core/Level.tscn
+++ b/scenes/core/Level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3]
+[gd_scene load_steps=11 format=3]
 
 [ext_resource type="Script" path="res://scripts/core/Level.gd" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/entities/Player.tscn" id="2"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" path="res://scenes/entities/Block.tscn" id="4"]
 [ext_resource type="PackedScene" path="res://scenes/core/HUD.tscn" id="5"]
 [ext_resource type="Script" path="res://scripts/core/GameManager.gd" id="6"]
+[ext_resource type="PackedScene" path="res://scenes/entities/PowerUp.tscn" id="7"]
 
 [sub_resource type="Image" id="1"]
 data = {
@@ -49,6 +50,12 @@ unique_name_in_owner = true
 unique_name_in_owner = true
 
 [node name="Block" parent="Blocks" instance=ExtResource("4")]
+unique_name_in_owner = true
+
+[node name="PowerUps" type="Node2D" parent="."]
+unique_name_in_owner = true
+
+[node name="PowerUp" parent="PowerUps" instance=ExtResource("7")]
 unique_name_in_owner = true
 
 [node name="HUD" parent="." instance=ExtResource("5")]

--- a/scenes/entities/PowerUp.tscn
+++ b/scenes/entities/PowerUp.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/entities/PowerUp.gd" id="1"]
+
+[sub_resource type="CircleShape2D" id="1"]
+radius = 24.0
+
+[node name="PowerUp" type="Area2D"]
+script = ExtResource("1")
+monitorable = true
+
+[node name="Body" type="Polygon2D" parent="."]
+polygon = PackedVector2Array(0, -20, 20, 0, 0, 20, -20, 0)
+color = Color(0.9, 0.2, 0.2, 1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")

--- a/scripts/core/Level.gd
+++ b/scripts/core/Level.gd
@@ -6,11 +6,13 @@ const Consts = preload("res://scripts/utils/constants.gd")
 const LevelLoader = preload("res://scripts/utils/level_loader.gd")
 const EnemyScene: PackedScene = preload("res://scenes/entities/Enemy.tscn")
 const BlockScene: PackedScene = preload("res://scenes/entities/Block.tscn")
+const PowerUpScene: PackedScene = preload("res://scenes/entities/PowerUp.tscn")
 @export var level_file: String = ""
 @onready var tile_map: TileMap = %GroundTileMap
 @onready var player: Player = %Player
 @onready var enemy_container: Node2D = %Enemies
 @onready var block_container: Node2D = %Blocks
+@onready var power_up_container: Node2D = %PowerUps
 @onready var hud: HUD = %HUD
 
 func _ready() -> void:
@@ -38,6 +40,7 @@ func _apply_level_data(data: Dictionary) -> void:
     _position_player(_get_dictionary(data, "player"))
     _spawn_entities(block_container, BlockScene, _get_array(data, "blocks"), Consts.BLOCK_START)
     _spawn_entities(enemy_container, EnemyScene, _get_array(data, "enemies"), Consts.ENEMY_START)
+    _spawn_power_ups(_get_array(data, "power_ups"))
     hud.offset = Vector2.ZERO
 
 func _populate_tile_map(width: int, height: int) -> void:
@@ -61,6 +64,22 @@ func _spawn_entities(container: Node2D, scene: PackedScene, entries: Array, fall
         instance.global_position = world_position
         container.add_child(instance)
         instance.set("target_position", world_position)
+
+func _spawn_power_ups(entries: Array) -> void:
+    _clear_container(power_up_container)
+    for entry: Variant in entries:
+        var grid_position: Vector2i = _extract_position(entry, Vector2i.ZERO)
+        var power_up: PowerUp = PowerUpScene.instantiate() as PowerUp
+        if entry is Dictionary:
+            var entry_dict: Dictionary = entry
+            if entry_dict.has("type"):
+                power_up.power_up_type = StringName(entry_dict["type"])
+            if entry_dict.has("score"):
+                power_up.score_value = int(entry_dict["score"])
+        var world_position: Vector2 = GameHelpers.grid_to_world(grid_position)
+        power_up.global_position = world_position
+        power_up.target_position = world_position
+        power_up_container.add_child(power_up)
 
 func _clear_container(container: Node) -> void:
     for child: Node in container.get_children():

--- a/scripts/entities/PowerUp.gd
+++ b/scripts/entities/PowerUp.gd
@@ -1,0 +1,47 @@
+## PowerUp gestiona la recogida de ítems de bonificación por el jugador.
+extends Area2D
+class_name PowerUp
+
+signal collected(power_up: PowerUp, score_awarded: int)
+
+const Consts = preload("res://scripts/utils/constants.gd")
+
+@export var power_up_type: StringName = "fruit"
+@export var score_value: int = 0
+var target_position: Vector2 = Vector2.ZERO
+var _collected: bool = false
+
+func _ready() -> void:
+    """Inicializa el power-up registrando señales y valores por defecto."""
+    add_to_group("power_ups")
+    body_entered.connect(_on_body_entered)
+    if score_value <= 0:
+        score_value = _resolve_score_from_type()
+
+func collect() -> void:
+    """Otorga la bonificación asociada si aún no fue recogido."""
+    if _collected:
+        return
+    _collected = true
+    var bonus: int = score_value if score_value > 0 else _resolve_score_from_type()
+    collected.emit(self, bonus)
+    _apply_score_bonus(bonus)
+    queue_free()
+
+func _on_body_entered(body: Node) -> void:
+    """Detecta al jugador y aplica la recogida automática."""
+    if body is Player:
+        collect()
+
+func _resolve_score_from_type() -> int:
+    """Resuelve la puntuación asociada al tipo configurado."""
+    var type_key := String(power_up_type)
+    if Consts.POWER_UP_SCORES.has(type_key):
+        return int(Consts.POWER_UP_SCORES[type_key])
+    return Consts.POWER_UP_DEFAULT_SCORE
+
+func _apply_score_bonus(bonus: int) -> void:
+    """Suma el puntaje del bonus a través del GameManager global."""
+    if bonus == 0:
+        return
+    GameManager.add_score(bonus)

--- a/scripts/utils/constants.gd
+++ b/scripts/utils/constants.gd
@@ -18,3 +18,9 @@ const LEVEL_SCENE_PATH := "res://scenes/core/Level.tscn"
 const MAIN_MENU_SCENE_PATH := "res://scenes/core/MainMenu.tscn"
 const LEVELS_DIR := "res://levels/"
 const DEFAULT_LEVEL_FILE := "level_01.json"
+const POWER_UP_DEFAULT_SCORE := 50
+const POWER_UP_SCORES := {
+    "fruit": 100,
+    "vegetable": 75,
+    "gem": 150,
+}

--- a/tests/integration/test_power_up_collection.gd
+++ b/tests/integration/test_power_up_collection.gd
@@ -1,0 +1,47 @@
+## TestPowerUpCollection verifica la integración de power-ups dentro de un nivel real.
+extends Node
+
+const LevelScene: PackedScene = preload("res://scenes/core/Level.tscn")
+const Consts = preload("res://scripts/utils/constants.gd")
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+
+func run_tests() -> Array:
+    """Ejecuta las pruebas de integración relacionadas con power-ups."""
+    return [
+        await _test_level_spawns_and_collects_power_up(),
+    ]
+
+func _test_level_spawns_and_collects_power_up() -> Dictionary:
+    var tracker := _connect_score_tracker()
+    var score_events := tracker["events"]
+    var score_callable: Callable = tracker["callable"]
+    var before_score: int = score_events["value"]
+    var level: Level = LevelScene.instantiate()
+    level.level_file = "res://levels/level_01.json"
+    add_child(level)
+    await get_tree().process_frame
+    var power_ups_container: Node2D = level.get_node("%PowerUps")
+    var spawned_count := power_ups_container.get_child_count()
+    var first_power_up: PowerUp = power_ups_container.get_child(0)
+    var grid_position: Vector2i = GameHelpers.world_to_grid(first_power_up.global_position)
+    first_power_up.collect()
+    var expected_bonus: int = int(Consts.POWER_UP_SCORES["fruit"])
+    var after_score: int = score_events["value"]
+    GameManager.add_score(-expected_bonus)
+    GameManager.score_changed.disconnect(score_callable)
+    level.queue_free()
+    return {
+        "name": "El nivel carga power-ups desde JSON y otorga puntos al recogerlos",
+        "passed": spawned_count >= 2 and grid_position == Vector2i(3, 1) and after_score == before_score + expected_bonus,
+    }
+
+func _connect_score_tracker() -> Dictionary:
+    var score_events := {"value": 0}
+    var score_callable := func(value: int) -> void:
+        score_events["value"] = value
+    GameManager.score_changed.connect(score_callable)
+    GameManager.add_score(0)
+    return {
+        "events": score_events,
+        "callable": score_callable,
+    }

--- a/tests/unit/test_power_up.gd
+++ b/tests/unit/test_power_up.gd
@@ -1,0 +1,67 @@
+## TestPowerUp valida la recogida de ítems de bonus y su integración con el GameManager.
+extends Node
+
+const PowerUpScene: PackedScene = preload("res://scenes/entities/PowerUp.tscn")
+const Consts = preload("res://scripts/utils/constants.gd")
+
+func run_tests() -> Array:
+    """Ejecuta los casos unitarios de los power-ups."""
+    return [
+        _test_collect_emits_signal_and_score(),
+        _test_collect_uses_custom_score(),
+    ]
+
+func _test_collect_emits_signal_and_score() -> Dictionary:
+    var tracker := _connect_score_tracker()
+    var score_events := tracker["events"]
+    var score_callable: Callable = tracker["callable"]
+    var before_score: int = score_events["value"]
+    var signal_tracker := {"value": 0}
+    var power_up: PowerUp = PowerUpScene.instantiate()
+    add_child(power_up)
+    power_up.power_up_type = StringName("fruit")
+    power_up.collected.connect(func(_item: PowerUp, amount: int) -> void: signal_tracker["value"] = amount)
+    power_up.collect()
+    var awarded: int = signal_tracker["value"]
+    var after_score: int = score_events["value"]
+    var expected: int = int(Consts.POWER_UP_SCORES["fruit"])
+    GameManager.add_score(-awarded)
+    GameManager.score_changed.disconnect(score_callable)
+    if is_instance_valid(power_up):
+        power_up.queue_free()
+    return {
+        "name": "El power-up de fruta suma el score y emite señal de recogida",
+        "passed": awarded == expected and after_score == before_score + expected,
+    }
+
+func _test_collect_uses_custom_score() -> Dictionary:
+    var tracker := _connect_score_tracker()
+    var score_events := tracker["events"]
+    var score_callable: Callable = tracker["callable"]
+    var before_score: int = score_events["value"]
+    var custom_score := 320
+    var power_up: PowerUp = PowerUpScene.instantiate()
+    add_child(power_up)
+    power_up.power_up_type = StringName("gem")
+    power_up.score_value = custom_score
+    power_up.collect()
+    var after_score: int = score_events["value"]
+    GameManager.add_score(-custom_score)
+    GameManager.score_changed.disconnect(score_callable)
+    if is_instance_valid(power_up):
+        power_up.queue_free()
+    return {
+        "name": "El power-up respeta un valor de score personalizado",
+        "passed": after_score == before_score + custom_score,
+    }
+
+func _connect_score_tracker() -> Dictionary:
+    var score_events := {"value": 0}
+    var score_callable := func(value: int) -> void:
+        score_events["value"] = value
+    GameManager.score_changed.connect(score_callable)
+    GameManager.add_score(0)
+    return {
+        "events": score_events,
+        "callable": score_callable,
+    }


### PR DESCRIPTION
## Summary
- add a reusable PowerUp entity with scoring logic and scene definition
- spawn power-ups from level data and seed the default level with collectible bonuses
- cover the new behavior with unit and integration tests and update the roadmap task

## Testing
- godot --headless --run-tests *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7902aa988330902d8c0f3d6e4f4f