### PR TITLE
Ensure player-block collisions favor blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
 - [x] Colisión de bloques con enemigos (enemigos aplastados)
 - [x] Power-ups y sistema de bonus (frutas/ítems)
 - [x] Niveles iniciales (carga desde JSON en /levels) — warnings de tipado corregidos en Level.gd
-- [ ] Colisión jugador/bloque: **el jugador nunca debe quedar debajo de un bloque** (bloques siempre se priorizan sobre el jugador al empujar/colisionar).
+- [x] Colisión jugador/bloque: **el jugador nunca debe quedar debajo de un bloque** (bloques siempre se priorizan sobre el jugador al empujar/colisionar).
 - [ ] Límites del mapa: agregar **bordes sólidos** que no puedan cruzarse (ni jugador, ni bloques, ni enemigos).
 - [ ] HUD reubicado:
   - [ ] Score en la **esquina superior derecha**.

--- a/scripts/entities/Block.gd
+++ b/scripts/entities/Block.gd
@@ -10,12 +10,14 @@ const BLOCK_KILL_SCORE := Consts.BLOCK_KILL_SCORE
 
 var current_state: Enums.BlockState = Enums.BlockState.STATIC
 var target_position: Vector2
+var _slide_origin: Vector2 = Vector2.ZERO
 var _kill_registered: bool = false
 
 
 func _ready() -> void:
     """Configura la posición objetivo inicial y registra el bloque."""
     target_position = global_position
+    _slide_origin = target_position
     add_to_group("blocks")
     body_entered.connect(_on_body_entered)
 
@@ -37,6 +39,7 @@ func request_slide(direction: Vector2i) -> bool:
     if GameHelpers.find_node_at_position("blocks", destination):
         return false
     _kill_registered = false
+    _slide_origin = target_position
     target_position = destination
     current_state = Enums.BlockState.SLIDING
     return true
@@ -86,3 +89,15 @@ func _finalize_slide() -> void:
         _kill_registered = false
         return
     current_state = Enums.BlockState.STATIC
+    _slide_origin = target_position
+
+
+func occupies_world_position(world_position: Vector2) -> bool:
+    """Indica si el bloque ocupa la casilla solicitada durante o después del deslizamiento."""
+    var tolerance := 1.0
+    if current_state == Enums.BlockState.SLIDING:
+        if target_position.distance_to(world_position) < tolerance:
+            return true
+        if _slide_origin.distance_to(world_position) < tolerance:
+            return true
+    return target_position.distance_to(world_position) < tolerance

--- a/scripts/utils/helpers.gd
+++ b/scripts/utils/helpers.gd
@@ -28,6 +28,9 @@ static func find_node_at_position(group_name: StringName, world_position: Vector
         if not node is Node2D:
             continue
         var node_2d: Node2D = node as Node2D
+        if node_2d.has_method("occupies_world_position"):
+            if node_2d.occupies_world_position(world_position):
+                return node_2d
         if node_2d.global_position.distance_to(world_position) < 1.0:
             return node_2d
     return null

--- a/tests/integration/sandbox_player_block.gd
+++ b/tests/integration/sandbox_player_block.gd
@@ -1,0 +1,18 @@
+## SandboxPlayerBlock simula un empuje del bloque mientras el jugador intenta avanzar.
+extends Node2D
+
+const Enums = preload("res://scripts/utils/enums.gd")
+
+@onready var block: Block = %Block
+@onready var player: Player = %Player
+
+func _ready() -> void:
+    """Inicia la interacción jugador/bloque al cargar el sandbox."""
+    call_deferred("_simulate_push")
+
+func _simulate_push() -> void:
+    """Solicita el movimiento del bloque y la intención de avance del jugador."""
+    block.request_slide(Vector2i.RIGHT)
+    player.state = Enums.PlayerState.IDLE
+    player.target_position = player.global_position
+    player._try_start_move(Vector2i.RIGHT)

--- a/tests/integration/sandbox_player_block.tscn
+++ b/tests/integration/sandbox_player_block.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=7 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/entities/Block.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/entities/Player.tscn" id="2"]
+[ext_resource type="Script" path="res://tests/integration/sandbox_player_block.gd" id="3"]
+
+[sub_resource type="Image" id="1"]
+data = {
+"data": PackedByteArray(220, 220, 220, 255),
+"format": "RGBA8",
+"height": 1,
+"mipmaps": false,
+"width": 1
+}
+
+[sub_resource type="ImageTexture" id="2"]
+image = SubResource("1")
+size = Vector2i(1, 1)
+
+[sub_resource type="TileSetAtlasSource" id="3"]
+texture = SubResource("2")
+texture_region_size = Vector2i(64, 64)
+0/0/size = Vector2i(1, 1)
+
+[sub_resource type="TileSet" id="4"]
+tile_size = Vector2i(64, 64)
+sources = {0: SubResource("3")}
+
+[node name="SandboxPlayerBlock" type="Node2D"]
+script = ExtResource("3")
+
+[node name="TileMap" type="TileMap" parent="."]
+tile_set = SubResource("4")
+
+[node name="Player" parent="." instance=ExtResource("2")]
+position = Vector2(96, 160)
+
+[node name="Block" parent="." instance=ExtResource("1")]
+position = Vector2(160, 160)

--- a/tests/unit/test_player_block_collision.gd
+++ b/tests/unit/test_player_block_collision.gd
@@ -1,0 +1,41 @@
+## TestPlayerBlockCollision verifica que el jugador no se superpone con un bloque en movimiento.
+extends Node
+
+const BlockScene: PackedScene = preload("res://scenes/entities/Block.tscn")
+const PlayerScene: PackedScene = preload("res://scenes/entities/Player.tscn")
+const Enums = preload("res://scripts/utils/enums.gd")
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+
+func run_tests() -> Array:
+    """Ejecuta las validaciones de colisión jugador/bloque."""
+    return [
+        _test_player_stays_behind_sliding_block(),
+    ]
+
+func _test_player_stays_behind_sliding_block() -> Dictionary:
+    var block: Block = BlockScene.instantiate()
+    var player: Player = PlayerScene.instantiate()
+    add_child(block)
+    add_child(player)
+    var block_grid := Vector2i.ZERO
+    var player_grid := Vector2i(-1, 0)
+    var block_start: Vector2 = GameHelpers.grid_to_world(block_grid)
+    var player_start: Vector2 = GameHelpers.grid_to_world(player_grid)
+    block.global_position = block_start
+    block.target_position = block_start
+    player.global_position = player_start
+    player.target_position = player_start
+    player.state = Enums.PlayerState.IDLE
+    var slide_started: bool = block.request_slide(Vector2i.RIGHT)
+    player._try_start_move(Vector2i.RIGHT)
+    var player_grid_after := GameHelpers.world_to_grid(player.target_position)
+    var block_grid_target := GameHelpers.world_to_grid(block.target_position)
+    var result := {
+        "name": "El jugador no avanza a la casilla ocupada por un bloque deslizándose",
+        "passed": slide_started
+            and player.state == Enums.PlayerState.IDLE
+            and player_grid_after != block_grid_target,
+    }
+    block.queue_free()
+    player.queue_free()
+    return result


### PR DESCRIPTION
## Summary
- track the origin cell for sliding blocks and expose occupancy information so they continue to block movement while moving
- extend the shared helper to consult node-specific occupancy checks and prevent the player from stepping into a sliding block
- add player vs. block collision unit/integration sandboxes and mark the backlog task as complete

## Testing
- not run (Godot command line runner not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc7b347d648330841dd32291a5c92d