### PR TITLE
Add solid map limits enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
 - [x] Power-ups y sistema de bonus (frutas/ítems)
 - [x] Niveles iniciales (carga desde JSON en /levels) — warnings de tipado corregidos en Level.gd
 - [x] Colisión jugador/bloque: **el jugador nunca debe quedar debajo de un bloque** (bloques siempre se priorizan sobre el jugador al empujar/colisionar).
-- [ ] Límites del mapa: agregar **bordes sólidos** que no puedan cruzarse (ni jugador, ni bloques, ni enemigos).
+- [x] Límites del mapa: agregar **bordes sólidos** que no puedan cruzarse (ni jugador, ni bloques, ni enemigos).
 - [ ] HUD reubicado:
   - [ ] Score en la **esquina superior derecha**.
   - [ ] Vidas en el **centro inferior**.

--- a/scripts/core/Level.gd
+++ b/scripts/core/Level.gd
@@ -36,6 +36,7 @@ func _apply_level_data(data: Dictionary) -> void:
     var grid_size: Dictionary = _get_dictionary(data, "grid_size")
     var width: int = int(grid_size.get("width", Consts.GRID_WIDTH))
     var height: int = int(grid_size.get("height", Consts.GRID_HEIGHT))
+    GameHelpers.set_map_bounds(Rect2i(Vector2i.ZERO, Vector2i(width, height)))
     _populate_tile_map(width, height)
     _position_player(_get_dictionary(data, "player"))
     _spawn_entities(block_container, BlockScene, _get_array(data, "blocks"), Consts.BLOCK_START)

--- a/scripts/entities/Block.gd
+++ b/scripts/entities/Block.gd
@@ -36,6 +36,9 @@ func request_slide(direction: Vector2i) -> bool:
     if current_state != Enums.BlockState.STATIC:
         return false
     var destination: Vector2 = target_position + Vector2(direction) * Consts.TILE_SIZE
+    var destination_grid: Vector2i = GameHelpers.world_to_grid(destination)
+    if not GameHelpers.is_within_bounds(destination_grid):
+        return false
     if GameHelpers.find_node_at_position("blocks", destination):
         return false
     _kill_registered = false

--- a/scripts/entities/Enemy.gd
+++ b/scripts/entities/Enemy.gd
@@ -73,6 +73,9 @@ func _advance(delta: float) -> void:
 func _attempt_step(direction: Vector2i) -> bool:
     """Calcula un destino potencial y valida colisiones básicas."""
     var destination: Vector2 = target_position + Vector2(direction) * Consts.TILE_SIZE
+    var destination_grid: Vector2i = GameHelpers.world_to_grid(destination)
+    if not GameHelpers.is_within_bounds(destination_grid):
+        return false
     if GameHelpers.find_node_at_position("blocks", destination):
         return false
     target_position = destination

--- a/scripts/entities/Player.gd
+++ b/scripts/entities/Player.gd
@@ -60,6 +60,9 @@ func _try_start_move(direction: Vector2i) -> void:
     if direction == Vector2i.ZERO:
         return
     var destination: Vector2 = target_position + Vector2(direction) * Consts.TILE_SIZE
+    var destination_grid: Vector2i = GameHelpers.world_to_grid(destination)
+    if not GameHelpers.is_within_bounds(destination_grid):
+        return
     var block_node: Node = GameHelpers.find_node_at_position("blocks", destination)
     if block_node and block_node is Block:
         if (block_node as Block).request_slide(direction):

--- a/scripts/utils/helpers.gd
+++ b/scripts/utils/helpers.gd
@@ -4,6 +4,7 @@ class_name GameHelpers
 
 const Consts = preload("res://scripts/utils/constants.gd")
 
+static var _map_bounds: Rect2i = Rect2i(Vector2i.ZERO, Vector2i(Consts.GRID_WIDTH, Consts.GRID_HEIGHT))
 
 static func grid_to_world(grid_position: Vector2i) -> Vector2:
     """Convierte una posición de grid a coordenadas globales."""
@@ -39,3 +40,18 @@ static func find_node_at_position(group_name: StringName, world_position: Vector
 static func get_tree() -> SceneTree:
     """Permite acceder al árbol de escenas desde un contexto estático."""
     return Engine.get_main_loop() as SceneTree
+
+
+static func set_map_bounds(bounds: Rect2i) -> void:
+    """Define los límites actuales del grid disponible para el nivel."""
+    _map_bounds = bounds
+
+
+static func get_map_bounds() -> Rect2i:
+    """Devuelve el rectángulo de límites configurado para el mapa."""
+    return _map_bounds
+
+
+static func is_within_bounds(grid_position: Vector2i) -> bool:
+    """Indica si la posición en grid se encuentra dentro de los límites actuales."""
+    return _map_bounds.has_point(grid_position)

--- a/tests/integration/sandbox_map_limits.gd
+++ b/tests/integration/sandbox_map_limits.gd
@@ -1,0 +1,27 @@
+## SandboxMapLimits configura un grid pequeño para visualizar los bordes del mapa.
+extends Node2D
+
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+
+@export var grid_size: Vector2i = Vector2i(5, 5)
+@onready var tile_map: TileMap = %GroundTileMap
+@onready var player: Player = %Player
+@onready var block: Block = %Block
+@onready var enemy: Enemy = %Enemy
+
+func _ready() -> void:
+    """Prepara un tablero compacto con posiciones iniciales seguras."""
+    GameHelpers.set_map_bounds(Rect2i(Vector2i.ZERO, grid_size))
+    _populate_tile_map()
+    player.global_position = GameHelpers.grid_to_world(Vector2i(1, 1))
+    player.target_position = player.global_position
+    block.global_position = GameHelpers.grid_to_world(Vector2i(grid_size.x - 2, 1))
+    block.target_position = block.global_position
+    enemy.global_position = GameHelpers.grid_to_world(Vector2i(1, grid_size.y - 2))
+    enemy.target_position = enemy.global_position
+
+func _populate_tile_map() -> void:
+    tile_map.clear()
+    for x in range(grid_size.x):
+        for y in range(grid_size.y):
+            tile_map.set_cell(0, Vector2i(x, y), 0, Vector2i.ZERO)

--- a/tests/integration/sandbox_map_limits.tscn
+++ b/tests/integration/sandbox_map_limits.tscn
@@ -1,0 +1,44 @@
+[gd_scene load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://tests/integration/sandbox_map_limits.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/entities/Player.tscn" id="2"]
+[ext_resource type="PackedScene" path="res://scenes/entities/Block.tscn" id="3"]
+[ext_resource type="PackedScene" path="res://scenes/entities/Enemy.tscn" id="4"]
+
+[sub_resource type="Image" id="1"]
+data = {
+"data": PackedByteArray(255, 255, 255, 255),
+"format": "RGBA8",
+"height": 1,
+"mipmaps": false,
+"width": 1
+}
+
+[sub_resource type="ImageTexture" id="2"]
+image = SubResource("1")
+size = Vector2i(1, 1)
+
+[sub_resource type="TileSetAtlasSource" id="3"]
+texture = SubResource("2")
+texture_region_size = Vector2i(64, 64)
+0/0/size = Vector2i(1, 1)
+
+[sub_resource type="TileSet" id="4"]
+tile_size = Vector2i(64, 64)
+sources = {0: SubResource("3")}
+
+[node name="SandboxMapLimits" type="Node2D"]
+script = ExtResource("1")
+
+[node name="GroundTileMap" type="TileMap" parent="."]
+unique_name_in_owner = true
+tile_set = SubResource("4")
+
+[node name="Player" parent="." instance=ExtResource("2")]
+unique_name_in_owner = true
+
+[node name="Block" parent="." instance=ExtResource("3")]
+unique_name_in_owner = true
+
+[node name="Enemy" parent="." instance=ExtResource("4")]
+unique_name_in_owner = true

--- a/tests/unit/test_map_limits.gd
+++ b/tests/unit/test_map_limits.gd
@@ -1,0 +1,77 @@
+## TestMapLimits garantiza que jugador, bloques y enemigos respeten los bordes del mapa.
+extends Node
+
+const PlayerScene: PackedScene = preload("res://scenes/entities/Player.tscn")
+const BlockScene: PackedScene = preload("res://scenes/entities/Block.tscn")
+const EnemyScene: PackedScene = preload("res://scenes/entities/Enemy.tscn")
+const Enums = preload("res://scripts/utils/enums.gd")
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+
+func run_tests() -> Array:
+    """Ejecuta todas las verificaciones relacionadas con los límites del mapa."""
+    return [
+        _test_player_cannot_exit_bounds(),
+        _test_block_cannot_slide_outside_bounds(),
+        _test_enemy_respects_bounds(),
+    ]
+
+func _test_player_cannot_exit_bounds() -> Dictionary:
+    var previous_bounds: Rect2i = GameHelpers.get_map_bounds()
+    var bounds := Rect2i(Vector2i.ZERO, Vector2i(2, 2))
+    GameHelpers.set_map_bounds(bounds)
+    var player: Player = PlayerScene.instantiate()
+    add_child(player)
+    var start_grid := Vector2i.ZERO
+    var start_world: Vector2 = GameHelpers.grid_to_world(start_grid)
+    player.global_position = start_world
+    player.target_position = start_world
+    player.state = Enums.PlayerState.IDLE
+    player._try_start_move(Vector2i.LEFT)
+    var result := {
+        "name": "El jugador no puede abandonar el grid por la izquierda",
+        "passed": player.target_position.is_equal_approx(start_world)
+            and player.state == Enums.PlayerState.IDLE,
+    }
+    player.queue_free()
+    GameHelpers.set_map_bounds(previous_bounds)
+    return result
+
+func _test_block_cannot_slide_outside_bounds() -> Dictionary:
+    var previous_bounds: Rect2i = GameHelpers.get_map_bounds()
+    var bounds := Rect2i(Vector2i.ZERO, Vector2i(2, 2))
+    GameHelpers.set_map_bounds(bounds)
+    var block: Block = BlockScene.instantiate()
+    add_child(block)
+    var start_grid := Vector2i(1, 0)
+    var start_world: Vector2 = GameHelpers.grid_to_world(start_grid)
+    block.global_position = start_world
+    block.target_position = start_world
+    var slide_started := block.request_slide(Vector2i.RIGHT)
+    var result := {
+        "name": "El bloque no se desliza fuera de los límites",
+        "passed": not slide_started
+            and block.target_position.is_equal_approx(start_world),
+    }
+    block.queue_free()
+    GameHelpers.set_map_bounds(previous_bounds)
+    return result
+
+func _test_enemy_respects_bounds() -> Dictionary:
+    var previous_bounds: Rect2i = GameHelpers.get_map_bounds()
+    var bounds := Rect2i(Vector2i.ZERO, Vector2i(2, 2))
+    GameHelpers.set_map_bounds(bounds)
+    var enemy: Enemy = EnemyScene.instantiate()
+    add_child(enemy)
+    var start_grid := Vector2i(1, 1)
+    var start_world: Vector2 = GameHelpers.grid_to_world(start_grid)
+    enemy.global_position = start_world
+    enemy.target_position = start_world
+    var step_allowed := enemy._attempt_step(Vector2i.RIGHT)
+    var result := {
+        "name": "El enemigo evita avanzar fuera del mapa",
+        "passed": not step_allowed
+            and enemy.target_position.is_equal_approx(start_world),
+    }
+    enemy.queue_free()
+    GameHelpers.set_map_bounds(previous_bounds)
+    return result


### PR DESCRIPTION
## Summary
- store map bounds in GameHelpers and have Level configure them from level data
- prevent players, enemies, and blocks from moving outside the configured grid limits
- add dedicated unit and integration assets to validate the map border behaviour and mark the backlog task as complete

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc7dd4148c833082d76345a5f05fc3