### PR TITLE
Reposition HUD and add level timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
 - [x] Niveles iniciales (carga desde JSON en /levels) — warnings de tipado corregidos en Level.gd
 - [x] Colisión jugador/bloque: **el jugador nunca debe quedar debajo de un bloque** (bloques siempre se priorizan sobre el jugador al empujar/colisionar).
 - [x] Límites del mapa: agregar **bordes sólidos** que no puedan cruzarse (ni jugador, ni bloques, ni enemigos).
-- [ ] HUD reubicado:
-  - [ ] Score en la **esquina superior derecha**.
-  - [ ] Vidas en el **centro inferior**.
-  - [ ] Level en la **esquina superior izquierda**.
-  - [ ] Timer en el **centro superior** (contando tiempo de cada nivel).
+- [x] HUD reubicado:
+  - [x] Score en la **esquina superior derecha**.
+  - [x] Vidas en el **centro inferior**.
+  - [x] Level en la **esquina superior izquierda**.
+  - [x] Timer en el **centro superior** (contando tiempo de cada nivel).
 - [ ] Sistema de transición de niveles (pasar al siguiente al derrotar enemigos)
 - [ ] Sistema de Game Over y reinicio
 - [ ] Menú principal funcional

--- a/scenes/core/HUD.tscn
+++ b/scenes/core/HUD.tscn
@@ -6,35 +6,57 @@
 script = ExtResource("1")
 layer = 1
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="Root" type="Control" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+
+[node name="LevelValue" type="Label" parent="Root"]
+unique_name_in_owner = true
 margin_left = 16.0
 margin_top = 16.0
+text = "Nivel"
+vertical_alignment = 1
+
+[node name="ScoreContainer" type="HBoxContainer" parent="Root"]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -220.0
+margin_top = 16.0
 margin_right = -16.0
-margin_bottom = -16.0
+alignment = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
-custom_minimum_size = Vector2(0, 120)
-
-[node name="ScoreRow" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
-
-[node name="ScoreTitle" type="Label" parent="MarginContainer/VBoxContainer/ScoreRow"]
+[node name="ScoreTitle" type="Label" parent="Root/ScoreContainer"]
 text = "Score:"
 
-[node name="ScoreLabel" type="Label" parent="MarginContainer/VBoxContainer/ScoreRow"]
+[node name="ScoreValue" type="Label" parent="Root/ScoreContainer"]
 unique_name_in_owner = true
 text = "0"
 
-[node name="LivesRow" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="TimerLabel" type="Label" parent="Root"]
+unique_name_in_owner = true
+anchor_left = 0.5
+anchor_right = 0.5
+margin_left = -80.0
+margin_top = 16.0
+margin_right = 80.0
+horizontal_alignment = 1
+text = "00:00"
+vertical_alignment = 1
 
-[node name="LivesTitle" type="Label" parent="MarginContainer/VBoxContainer/LivesRow"]
+[node name="LivesContainer" type="HBoxContainer" parent="Root"]
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+margin_left = -120.0
+margin_top = -48.0
+margin_right = 120.0
+margin_bottom = -16.0
+alignment = 1
+
+[node name="LivesTitle" type="Label" parent="Root/LivesContainer"]
 text = "Vidas:"
 
-[node name="LivesLabel" type="Label" parent="MarginContainer/VBoxContainer/LivesRow"]
+[node name="LivesValue" type="Label" parent="Root/LivesContainer"]
 unique_name_in_owner = true
 text = "3"
-
-[node name="LevelLabel" type="Label" parent="MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-text = "Nivel"

--- a/scripts/core/HUD.gd
+++ b/scripts/core/HUD.gd
@@ -1,20 +1,37 @@
-## HUD gestiona la visualización del score, vidas y nombre del nivel mediante señales.
+## HUD gestiona la visualización del score, vidas, nivel y temporizador del nivel.
 extends CanvasLayer
 class_name HUD
 
 signal score_updated(new_score: int)
 signal lives_updated(new_lives: int)
 
-@onready var score_label: Label = %ScoreLabel
-@onready var lives_label: Label = %LivesLabel
-@onready var level_label: Label = %LevelLabel
+@onready var score_label: Label = %ScoreValue
+@onready var lives_label: Label = %LivesValue
+@onready var level_label: Label = %LevelValue
+@onready var timer_label: Label = %TimerLabel
+
+var _is_timer_running := false
+var _elapsed_time := 0.0
+
 
 func _ready() -> void:
     """Conecta el HUD al GameManager y muestra valores iniciales."""
+    set_process(true)
+    timer_label.text = _format_time(0.0)
     GameManager.score_changed.connect(_on_score_changed)
     GameManager.lives_changed.connect(_on_lives_changed)
     GameManager.level_started.connect(_on_level_started)
+    GameManager.game_over.connect(_on_game_over)
     GameManager.register_hud(self)
+
+
+func _process(delta: float) -> void:
+    """Actualiza el temporizador cuando el nivel está activo."""
+    if not _is_timer_running:
+        return
+
+    _elapsed_time += delta
+    timer_label.text = _format_time(_elapsed_time)
 
 
 func _on_score_changed(value: int) -> void:
@@ -30,5 +47,21 @@ func _on_lives_changed(value: int) -> void:
 
 
 func _on_level_started(level_name: String) -> void:
-    """Muestra el nombre del nivel activo."""
+    """Muestra el nombre del nivel activo y reinicia el temporizador."""
     level_label.text = level_name
+    _elapsed_time = 0.0
+    timer_label.text = _format_time(_elapsed_time)
+    _is_timer_running = true
+
+
+func _on_game_over() -> void:
+    """Detiene el temporizador cuando el juego termina."""
+    _is_timer_running = false
+
+
+func _format_time(time_seconds: float) -> String:
+    """Convierte segundos en formato MM:SS."""
+    var total_seconds: int = int(time_seconds)
+    var minutes := total_seconds / 60
+    var seconds := total_seconds % 60
+    return "%02d:%02d" % [minutes, seconds]

--- a/tests/integration/sandbox_hud.gd
+++ b/tests/integration/sandbox_hud.gd
@@ -1,0 +1,8 @@
+## SandboxHUD permite visualizar la reubicación del HUD y el temporizador.
+extends Node2D
+
+func _ready() -> void:
+    """Inicializa valores de ejemplo para visualizar el HUD."""
+    GameManager.add_score(100)
+    GameManager.set_lives(5)
+    GameManager.level_started.emit("Sandbox HUD")

--- a/tests/integration/sandbox_hud.tscn
+++ b/tests/integration/sandbox_hud.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/core/HUD.tscn" id="1"]
+[ext_resource type="Script" path="res://tests/integration/sandbox_hud.gd" id="2"]
+
+[node name="HUDSandbox" type="Node2D"]
+script = ExtResource("2")
+
+[node name="HUD" parent="." instance=ExtResource("1")]

--- a/tests/unit/test_hud.gd
+++ b/tests/unit/test_hud.gd
@@ -1,0 +1,76 @@
+## TestHUD verifica que el HUD actualiza sus elementos visuales y el temporizador.
+extends Node
+
+const HUDScene: PackedScene = preload("res://scenes/core/HUD.tscn")
+
+class GameManagerStub:
+    extends Node
+    signal score_changed(new_score: int)
+    signal lives_changed(new_lives: int)
+    signal level_started(level_name: String)
+    signal game_over()
+    var registered_hud: HUD
+
+    func register_hud(hud: HUD) -> void:
+        registered_hud = hud
+
+
+func run_tests() -> Array:
+    """Ejecuta los tests asociados al HUD."""
+    return [
+        await _test_score_and_lives_update_labels(),
+        await _test_level_timer_formats_and_stops(),
+    ]
+
+
+func _test_score_and_lives_update_labels() -> Dictionary:
+    var original_game_manager := GameManager
+    var stub := GameManagerStub.new()
+    GameManager = stub
+    add_child(stub)
+    var hud: HUD = HUDScene.instantiate()
+    add_child(hud)
+    await get_tree().process_frame
+    stub.score_changed.emit(450)
+    stub.lives_changed.emit(2)
+    var score_label: Label = hud.get_node("Root/ScoreContainer/ScoreValue")
+    var lives_label: Label = hud.get_node("Root/LivesContainer/LivesValue")
+    var result := {
+        "name": "HUD refleja las actualizaciones de score y vidas",
+        "passed": score_label.text == "450" and lives_label.text == "2" and stub.registered_hud == hud,
+    }
+    hud.queue_free()
+    stub.queue_free()
+    GameManager = original_game_manager
+    return result
+
+
+func _test_level_timer_formats_and_stops() -> Dictionary:
+    var original_game_manager := GameManager
+    var stub := GameManagerStub.new()
+    GameManager = stub
+    add_child(stub)
+    var hud: HUD = HUDScene.instantiate()
+    add_child(hud)
+    await get_tree().process_frame
+    var level_label: Label = hud.get_node("Root/LevelValue")
+    var timer_label: Label = hud.get_node("Root/TimerLabel")
+    var initial_timer_text := timer_label.text
+    stub.level_started.emit("Nivel 1")
+    hud._process(65.2)
+    var running_timer_text := timer_label.text
+    var running_level_name := level_label.text
+    stub.game_over.emit()
+    hud._process(1.0)
+    var stopped_timer_text := timer_label.text
+    var result := {
+        "name": "HUD reinicia el temporizador por nivel y lo detiene en Game Over",
+        "passed": initial_timer_text == "00:00"
+            and running_level_name == "Nivel 1"
+            and running_timer_text == "01:05"
+            and stopped_timer_text == "01:05",
+    }
+    hud.queue_free()
+    stub.queue_free()
+    GameManager = original_game_manager
+    return result


### PR DESCRIPTION
## Summary
- reposition the HUD layout to place score, level, lives, and timer according to the specification
- add a per-level timer that resets on level start and pauses on game over
- document the change in the README, add HUD unit tests, and provide a sandbox scene for manual checks

## Testing
- not run (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc7f87ea908330a2d592175e53d109