### PR TITLE
Center maps and highlight non-playable area

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
   - [x] Vidas en el **centro inferior**.
   - [x] Level en la **esquina superior izquierda**.
   - [x] Timer en el **centro superior** (contando tiempo de cada nivel).
-- [ ] Mapas centrados y área de no tránsito diferenciada.
+- [x] Mapas centrados y área de no tránsito diferenciada.
 - [ ] Sistema de transición de niveles (pasar al siguiente al derrotar enemigos)
 - [ ] Sistema de Game Over y reinicio
 - [ ] Menú principal funcional

--- a/scenes/core/Level.tscn
+++ b/scenes/core/Level.tscn
@@ -33,6 +33,16 @@ sources = {0: SubResource("3")}
 [node name="Level" type="Node2D"]
 script = ExtResource("1")
 
+[node name="NonPlayableBackground" type="ColorRect" parent="."]
+unique_name_in_owner = true
+mouse_filter = 2
+color = Color(0.0470588, 0.0470588, 0.0705882, 1)
+
+[node name="PlayableArea" type="ColorRect" parent="."]
+unique_name_in_owner = true
+mouse_filter = 2
+color = Color(0.0941176, 0.145098, 0.227451, 1)
+
 [node name="GroundTileMap" type="TileMap" parent="."]
 unique_name_in_owner = true
 tile_set = SubResource("4")

--- a/scripts/utils/helpers.gd
+++ b/scripts/utils/helpers.gd
@@ -5,20 +5,21 @@ class_name GameHelpers
 const Consts = preload("res://scripts/utils/constants.gd")
 
 static var _map_bounds: Rect2i = Rect2i(Vector2i.ZERO, Vector2i(Consts.GRID_WIDTH, Consts.GRID_HEIGHT))
+static var _map_offset: Vector2 = Vector2.ZERO
 
 static func grid_to_world(grid_position: Vector2i) -> Vector2:
     """Convierte una posición de grid a coordenadas globales."""
     var tile_size: float = Consts.TILE_SIZE
     var half_tile: Vector2 = Vector2.ONE * (tile_size * 0.5)
     var grid_position_vector: Vector2 = Vector2(grid_position)
-    return grid_position_vector * tile_size + half_tile
+    return grid_position_vector * tile_size + half_tile + _map_offset
 
 
 static func world_to_grid(world_position: Vector2) -> Vector2i:
     """Convierte una posición global a coordenadas del grid."""
     var tile_size: float = Consts.TILE_SIZE
     var half_tile: Vector2 = Vector2.ONE * (tile_size * 0.5)
-    var adjusted: Vector2 = world_position - half_tile
+    var adjusted: Vector2 = world_position - half_tile - _map_offset
     return Vector2i(round(adjusted.x / tile_size), round(adjusted.y / tile_size))
 
 
@@ -55,3 +56,20 @@ static func get_map_bounds() -> Rect2i:
 static func is_within_bounds(grid_position: Vector2i) -> bool:
     """Indica si la posición en grid se encuentra dentro de los límites actuales."""
     return _map_bounds.has_point(grid_position)
+
+
+static func set_map_offset(offset: Vector2) -> void:
+    """Almacena el desplazamiento en píxeles usado para centrar el grid."""
+    _map_offset = offset
+
+
+static func get_map_offset() -> Vector2:
+    """Devuelve el desplazamiento actual aplicado al grid en coordenadas mundiales."""
+    return _map_offset
+
+
+static func calculate_center_offset(grid_size: Vector2i, viewport_size: Vector2) -> Vector2:
+    """Calcula el offset necesario para centrar el mapa dentro del viewport."""
+    var grid_pixel_size: Vector2 = Vector2(grid_size) * Consts.TILE_SIZE
+    var offset: Vector2 = (viewport_size - grid_pixel_size) * 0.5
+    return Vector2(max(offset.x, 0.0), max(offset.y, 0.0))

--- a/tests/integration/sandbox_centered_map.tscn
+++ b/tests/integration/sandbox_centered_map.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/core/Level.tscn" id="1"]
+
+[node name="SandboxCenteredMap" type="Node2D"]
+
+[node name="Level" parent="." instance=ExtResource("1")]
+unique_name_in_owner = true

--- a/tests/unit/test_map_centering.gd
+++ b/tests/unit/test_map_centering.gd
@@ -1,0 +1,30 @@
+## TestMapCentering valida que el offset calculado centre el grid en el viewport.
+extends Node
+
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+const Consts = preload("res://scripts/utils/constants.gd")
+
+func run_tests() -> Array:
+    return [
+        _test_offset_is_centered_when_viewport_is_larger(),
+        _test_offset_is_clamped_when_viewport_is_smaller(),
+    ]
+
+func _test_offset_is_centered_when_viewport_is_larger() -> Dictionary:
+    var grid_size := Vector2i(5, 4)
+    var viewport_size := Vector2(1280, 720)
+    var expected := (viewport_size - Vector2(grid_size) * Consts.TILE_SIZE) * 0.5
+    var offset := GameHelpers.calculate_center_offset(grid_size, viewport_size)
+    return {
+        "name": "El offset centra el mapa cuando el viewport es amplio",
+        "passed": offset.is_equal_approx(expected),
+    }
+
+func _test_offset_is_clamped_when_viewport_is_smaller() -> Dictionary:
+    var grid_size := Vector2i(10, 8)
+    var viewport_size := Vector2(200, 150)
+    var offset := GameHelpers.calculate_center_offset(grid_size, viewport_size)
+    return {
+        "name": "El offset se ajusta a cero cuando el viewport es menor al mapa",
+        "passed": offset == Vector2.ZERO,
+    }

--- a/tests/unit/test_out_of_bounds.gd
+++ b/tests/unit/test_out_of_bounds.gd
@@ -1,0 +1,52 @@
+## TestOutOfBounds verifica que el offset del mapa no permita abandonar el área jugable.
+extends Node
+
+const PlayerScene: PackedScene = preload("res://scenes/entities/Player.tscn")
+const Enums = preload("res://scripts/utils/enums.gd")
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+
+func run_tests() -> Array:
+    return [
+        _test_world_and_grid_conversions_respect_offset(),
+        _test_player_cannot_move_beyond_bounds_with_offset(),
+    ]
+
+func _test_world_and_grid_conversions_respect_offset() -> Dictionary:
+    var previous_bounds: Rect2i = GameHelpers.get_map_bounds()
+    var previous_offset: Vector2 = GameHelpers.get_map_offset()
+    var grid_size := Vector2i(4, 3)
+    GameHelpers.set_map_bounds(Rect2i(Vector2i.ZERO, grid_size))
+    GameHelpers.set_map_offset(Vector2(96, 64))
+    var grid_position := Vector2i(2, 1)
+    var world_position := GameHelpers.grid_to_world(grid_position)
+    var converted := GameHelpers.world_to_grid(world_position)
+    var result := {
+        "name": "La conversión grid↔world mantiene la posición con offset",
+        "passed": converted == grid_position,
+    }
+    GameHelpers.set_map_bounds(previous_bounds)
+    GameHelpers.set_map_offset(previous_offset)
+    return result
+
+func _test_player_cannot_move_beyond_bounds_with_offset() -> Dictionary:
+    var previous_bounds: Rect2i = GameHelpers.get_map_bounds()
+    var previous_offset: Vector2 = GameHelpers.get_map_offset()
+    GameHelpers.set_map_bounds(Rect2i(Vector2i.ZERO, Vector2i(2, 2)))
+    GameHelpers.set_map_offset(Vector2(128, 80))
+    var player: Player = PlayerScene.instantiate()
+    add_child(player)
+    var start_grid := Vector2i(1, 0)
+    var start_world: Vector2 = GameHelpers.grid_to_world(start_grid)
+    player.global_position = start_world
+    player.target_position = start_world
+    player.state = Enums.PlayerState.IDLE
+    player._try_start_move(Vector2i.RIGHT)
+    var result := {
+        "name": "El jugador no abandona el área jugable aunque el mapa tenga offset",
+        "passed": player.target_position.is_equal_approx(start_world)
+            and player.state == Enums.PlayerState.IDLE,
+    }
+    player.queue_free()
+    GameHelpers.set_map_bounds(previous_bounds)
+    GameHelpers.set_map_offset(previous_offset)
+    return result


### PR DESCRIPTION
## Summary
- center the level tilemap within the viewport and share the offset via GameHelpers for consistent entity placement
- add color-coded backgrounds in the Level scene to differentiate the non-playable area from the grid
- create unit coverage for offset calculations and bounds enforcement plus an integration sandbox for visual checks

## Testing
- Not run (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc8a143ed083309d03cb11b666bb6d