### PR TITLE
Handle viewport resizing via signal

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,7 @@ Clonar en Godot el juego arcade *Don’t Pull* (Capcom, 1991 dentro de Three Won
   - Jugador (Player.tscn).
   - Enemigos (Enemy.tscn).
   - HUD (HUD.tscn).
+  - `Level.gd` escucha el signal `size_changed` del `Viewport` para recentrar el mapa ante cambios de tamaño.
 - `/scenes/Systems`
   - ScoreManager.gd
   - LevelManager.gd

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -106,3 +106,9 @@
   - /tests/unit/test_map_centering.gd → validar que el offset del mapa centra el grid en pantalla.
   - /tests/unit/test_out_of_bounds.gd → validar que jugador/bloques no pueden moverse fuera del área jugable.
   - /tests/integration/sandbox_centered_map.tscn → cargar un nivel pequeño y comprobar que aparece centrado con fondo diferenciado.
+
+---
+
+## Migraciones
+
+- NOTIFICATION_RESIZED (Godot 3.x) → reemplazado por signal `size_changed` en Godot 4.x.

--- a/scripts/core/Level.gd
+++ b/scripts/core/Level.gd
@@ -21,11 +21,15 @@ var _current_grid_size: Vector2i = Vector2i(Consts.GRID_WIDTH, Consts.GRID_HEIGH
 func _ready() -> void:
     """Carga los datos del nivel y posiciona entidades según el layout."""
     _apply_level_data(_load_level_data())
+    var viewport: Viewport = get_viewport()
+    if viewport != null:
+        viewport.connect("size_changed", Callable(self, "_on_viewport_resized"))
+    _update_map_layout()
     GameManager.start_level()
 
-func _notification(what: int) -> void:
-    if what == NOTIFICATION_RESIZED:
-        _update_map_layout()
+func _on_viewport_resized() -> void:
+    """Actualiza el layout del mapa cuando cambia el tamaño del viewport."""
+    _update_map_layout()
 
 func _load_level_data() -> Dictionary:
     var path: String = level_file if level_file != "" else LevelLoader.get_default_level_path()


### PR DESCRIPTION
## Summary
- connect the Level scene to the viewport's `size_changed` signal and recenter the map when the window resizes
- refresh the map layout on startup after loading level data
- document the new viewport dependency and note the migration from `NOTIFICATION_RESIZED` to `size_changed`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc8d89ea008330bac1302f8ed83fb4