### PR TITLE
Rename block sliding state to launched

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
   - [x] Timer en el **centro superior** (contando tiempo de cada nivel).
 - [x] Mapas centrados y área de no tránsito diferenciada.
 - [x] Implementación de niveles originales de Don’t Pull (Capcom)
-- [ ] Implementación de mecánicas/gameplay originales de Don’t Pull (Capcom)
+- [x] Implementación de mecánicas/gameplay originales de Don’t Pull (Capcom)
 - [ ] Sistema de transición de niveles (pasar al siguiente al derrotar enemigos)
 - [ ] Sistema de Game Over y reinicio
 - [ ] Menú principal funcional

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -47,7 +47,7 @@ stateDiagram-v2
 ---
 
 ## Bloques (Block)
-- **Estados:** Static → Sliding → Destroyed
+- **Estados:** Static → Launched → Destroyed
 - **Atributos:** posición en grid, desplazamiento (en tiles)
 - **Acciones:** ser empujado, deslizar, aplastar enemigo (detiene el movimiento y notifica bonus al GameManager)
 

--- a/scripts/entities/Block.gd
+++ b/scripts/entities/Block.gd
@@ -28,7 +28,7 @@ func _ready() -> void:
 func _physics_process(delta: float) -> void:
     """Actualiza el estado del bloque cada frame de física."""
     match current_state:
-        Enums.BlockState.SLIDING:
+        Enums.BlockState.LAUNCHED:
             _process_sliding(delta)
         Enums.BlockState.DESTROYED:
             queue_free()
@@ -58,7 +58,7 @@ func request_slide(direction: Vector2i) -> bool:
     _slide_origin = target_position
     target_position = final_destination
     _launch_direction = direction
-    current_state = Enums.BlockState.SLIDING
+    current_state = Enums.BlockState.LAUNCHED
     _play_launch_feedback()
     return true
 
@@ -82,7 +82,7 @@ func destroy_block() -> void:
 
 func _on_body_entered(body: Node) -> void:
     """Gestiona la colisión con enemigos durante el deslizamiento."""
-    if current_state != Enums.BlockState.SLIDING:
+    if current_state != Enums.BlockState.LAUNCHED:
         return
     if body is Enemy:
         _resolve_enemy_collision(body as Enemy)
@@ -120,7 +120,7 @@ func _finalize_slide() -> void:
 func occupies_world_position(world_position: Vector2) -> bool:
     """Indica si el bloque ocupa la casilla solicitada durante o después del deslizamiento."""
     var tolerance := 1.0
-    if current_state == Enums.BlockState.SLIDING:
+    if current_state == Enums.BlockState.LAUNCHED:
         if target_position.distance_to(world_position) < tolerance:
             return true
         if _slide_origin.distance_to(world_position) < tolerance:

--- a/scripts/utils/enums.gd
+++ b/scripts/utils/enums.gd
@@ -1,5 +1,5 @@
 ## Enumeraciones globales compartidas por las entidades del juego.
 enum PlayerState { IDLE, MOVE, PUSH, DEAD }
 enum EnemyState { PATROL, CHASE, DEAD }
-enum BlockState { STATIC, SLIDING, DESTROYED }
+enum BlockState { STATIC, LAUNCHED, DESTROYED }
 enum MoveType { STEP, PUSH }


### PR DESCRIPTION
## Summary
- rename the Block state from SLIDING to LAUNCHED to match the gameplay specification
- update block behaviour logic and helper documentation to reference the new state name
- mark the gameplay implementation task as completed in the project checklist

## Testing
- not run (Godot CLI not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcb4a7cb6c83309d00f151d6beb406