### PR TITLE
Align viewport bounds with playable grid

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -22,8 +22,8 @@ GameManager="*res://scripts/core/GameManager.gd"
 
 window/size/viewport_width=640
 window/size/viewport_height=640
-window/stretch/mode="canvas_items"
-window/stretch/aspect="expand"
+window/stretch/mode="2d"
+window/stretch/aspect="keep"
 
 [dotnet]
 

--- a/scenes/core/Level.tscn
+++ b/scenes/core/Level.tscn
@@ -33,6 +33,10 @@ sources = {0: SubResource("3")}
 [node name="Level" type="Node2D"]
 script = ExtResource("1")
 
+[node name="Camera2D" type="Camera2D" parent="."]
+unique_name_in_owner = true
+current = true
+
 [node name="NonPlayableBackground" type="ColorRect" parent="."]
 unique_name_in_owner = true
 mouse_filter = 2

--- a/scripts/core/Level.gd
+++ b/scripts/core/Level.gd
@@ -16,6 +16,7 @@ const PowerUpScene: PackedScene = preload("res://scenes/entities/PowerUp.tscn")
 @onready var hud: HUD = %HUD
 @onready var non_playable_background: ColorRect = %NonPlayableBackground
 @onready var playable_area_rect: ColorRect = %PlayableArea
+@onready var camera: Camera2D = %Camera2D
 var _current_grid_size: Vector2i = Vector2i(Consts.GRID_WIDTH, Consts.GRID_HEIGHT)
 var _level_name: String = ""
 
@@ -63,7 +64,8 @@ func _apply_level_data(data: Dictionary) -> void:
 
 func _update_map_layout() -> void:
     var viewport_size: Vector2 = get_viewport_rect().size
-    var offset: Vector2 = GameHelpers.calculate_center_offset(_current_grid_size, viewport_size)
+    var grid_pixel_size: Vector2 = Vector2(_current_grid_size) * Consts.TILE_SIZE
+    var offset: Vector2 = GameHelpers.calculate_center_offset(_current_grid_size, viewport_size).floor()
     GameHelpers.set_map_offset(offset)
     tile_map.position = offset
     if is_instance_valid(non_playable_background):
@@ -71,7 +73,13 @@ func _update_map_layout() -> void:
         non_playable_background.size = viewport_size
     if is_instance_valid(playable_area_rect):
         playable_area_rect.position = offset
-        playable_area_rect.size = Vector2(_current_grid_size) * Consts.TILE_SIZE
+        playable_area_rect.size = grid_pixel_size
+    if is_instance_valid(camera):
+        camera.position = offset + grid_pixel_size * 0.5
+        camera.limit_left = int(offset.x)
+        camera.limit_top = int(offset.y)
+        camera.limit_right = int(offset.x + grid_pixel_size.x)
+        camera.limit_bottom = int(offset.y + grid_pixel_size.y)
 
 func _populate_tile_map(width: int, height: int) -> void:
     tile_map.clear()

--- a/tests/integration/sandbox_resolution.gd
+++ b/tests/integration/sandbox_resolution.gd
@@ -1,0 +1,39 @@
+## SandboxResolution permite alternar resoluciones para validar que no existan áreas invisibles.
+extends Node2D
+
+const LevelScene: PackedScene = preload("res://scenes/core/Level.tscn")
+
+@export var resolutions: Array[Vector2i] = [
+    Vector2i(640, 640),
+    Vector2i(960, 720),
+    Vector2i(1280, 720),
+]
+
+var _resolution_index := 0
+var _level: Level
+@onready var resolution_label: Label = %ResolutionLabel
+
+func _ready() -> void:
+    """Instancia el nivel base y fija la resolución inicial."""
+    _level = LevelScene.instantiate()
+    add_child(_level)
+    _apply_resolution(resolutions[_resolution_index])
+    _update_label()
+
+func _unhandled_input(event: InputEvent) -> void:
+    """Permite cambiar de resolución con las flechas laterales."""
+    if event.is_action_pressed("ui_right"):
+        _resolution_index = (_resolution_index + 1) % resolutions.size()
+        _apply_resolution(resolutions[_resolution_index])
+        _update_label()
+    elif event.is_action_pressed("ui_left"):
+        _resolution_index = (_resolution_index - 1 + resolutions.size()) % resolutions.size()
+        _apply_resolution(resolutions[_resolution_index])
+        _update_label()
+
+func _apply_resolution(size: Vector2i) -> void:
+    get_viewport().size = size
+
+func _update_label() -> void:
+    var active_size := resolutions[_resolution_index]
+    resolution_label.text = "Resolución: %dx%d" % [active_size.x, active_size.y]

--- a/tests/integration/sandbox_resolution.tscn
+++ b/tests/integration/sandbox_resolution.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/integration/sandbox_resolution.gd" id="1"]
+
+[node name="SandboxResolution" type="Node2D"]
+script = ExtResource("1")
+
+[node name="UI" type="CanvasLayer" parent="."]
+layer = 1
+
+[node name="ResolutionLabel" type="Label" parent="UI"]
+unique_name_in_owner = true
+anchors_preset = 0
+offset_left = 16.0
+offset_top = 16.0
+text = "Resolución: 0x0"

--- a/tests/unit/test_viewport_bounds.gd
+++ b/tests/unit/test_viewport_bounds.gd
@@ -1,0 +1,76 @@
+## TestViewportBounds comprueba que el área visible coincide con los límites de colisión.
+extends Node
+
+const LevelScene: PackedScene = preload("res://scenes/core/Level.tscn")
+const Consts = preload("res://scripts/utils/constants.gd")
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+
+func run_tests() -> Array:
+    return [
+        await _test_playable_area_matches_bounds(),
+        await _test_letterbox_background_tracks_viewport(),
+    ]
+
+func _test_playable_area_matches_bounds() -> Dictionary:
+    var previous_bounds: Rect2i = GameHelpers.get_map_bounds()
+    var previous_offset: Vector2 = GameHelpers.get_map_offset()
+    var level: Level = LevelScene.instantiate()
+    add_child(level)
+    await get_tree().process_frame
+    var bounds: Rect2i = GameHelpers.get_map_bounds()
+    var expected_size: Vector2 = Vector2(bounds.size) * Consts.TILE_SIZE
+    var offset: Vector2 = GameHelpers.get_map_offset()
+    var playable_area: ColorRect = level.get_node("%PlayableArea")
+    var tile_map: TileMap = level.get_node("%GroundTileMap")
+    var last_cell_center: Vector2 = GameHelpers.grid_to_world(bounds.position + bounds.size - Vector2i.ONE)
+    var first_cell_center: Vector2 = GameHelpers.grid_to_world(bounds.position)
+    var playable_rect := Rect2(offset, expected_size)
+    var all_checks := playable_area.position.is_equal_approx(offset)
+        and playable_area.size.is_equal_approx(expected_size)
+        and tile_map.position.is_equal_approx(offset)
+        and playable_rect.has_point(first_cell_center)
+        and playable_rect.has_point(last_cell_center)
+    level.queue_free()
+    await get_tree().process_frame
+    GameHelpers.set_map_bounds(previous_bounds)
+    GameHelpers.set_map_offset(previous_offset)
+    return {
+        "name": "El rectángulo visible coincide con el grid definido por colisiones",
+        "passed": all_checks,
+    }
+
+func _test_letterbox_background_tracks_viewport() -> Dictionary:
+    var previous_bounds: Rect2i = GameHelpers.get_map_bounds()
+    var previous_offset: Vector2 = GameHelpers.get_map_offset()
+    var level: Level = LevelScene.instantiate()
+    add_child(level)
+    await get_tree().process_frame
+    var viewport: Viewport = level.get_viewport()
+    var original_size: Vector2i = viewport.size
+    var test_size := Vector2i(960, 720)
+    viewport.size = test_size
+    await get_tree().process_frame
+    await get_tree().process_frame
+    var viewport_size: Vector2 = level.get_viewport_rect().size
+    var background: ColorRect = level.get_node("%NonPlayableBackground")
+    var playable_area: ColorRect = level.get_node("%PlayableArea")
+    var camera: Camera2D = level.get_node("%Camera2D")
+    var bounds: Rect2i = GameHelpers.get_map_bounds()
+    var expected_size: Vector2 = Vector2(bounds.size) * Consts.TILE_SIZE
+    var offset: Vector2 = GameHelpers.get_map_offset()
+    var camera_expected_position: Vector2 = offset + expected_size * 0.5
+    var checks := background.position.is_equal_approx(Vector2.ZERO)
+        and background.size.is_equal_approx(viewport_size)
+        and playable_area.position.is_equal_approx(offset)
+        and playable_area.size.is_equal_approx(expected_size)
+        and camera.position.is_equal_approx(camera_expected_position)
+    viewport.size = original_size
+    await get_tree().process_frame
+    level.queue_free()
+    await get_tree().process_frame
+    GameHelpers.set_map_bounds(previous_bounds)
+    GameHelpers.set_map_offset(previous_offset)
+    return {
+        "name": "El letterboxing cubre el viewport y la cámara permanece centrada",
+        "passed": checks,
+    }


### PR DESCRIPTION
## Summary
- switch the project stretch mode to 2D with a kept aspect ratio to avoid rendering space outside the level grid
- center the level camera and background elements on the computed grid size so the visible area matches collision bounds
- add a regression unit test plus a manual sandbox scene to validate viewport behaviour at multiple resolutions

## Testing
- not run (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcb80f2e5c8330aafe7dcf3f65b379