### PR TITLE
Adjust viewport scaling and add camera centering tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
 - [x] Mapas centrados y área de no tránsito diferenciada.
 - [x] Implementación de niveles originales de Don’t Pull (Capcom)
 - [x] Implementación de mecánicas/gameplay originales de Don’t Pull (Capcom)
-- [ ] Ajuste de resolución, escalado y centrado del área jugable
+- [x] Ajuste de resolución, escalado y centrado del área jugable
 - [ ] Sistema de transición de niveles (pasar al siguiente al derrotar enemigos)
 - [ ] Sistema de Game Over y reinicio
 - [ ] Menú principal funcional

--- a/project.godot
+++ b/project.godot
@@ -21,7 +21,7 @@ GameManager="*res://scripts/core/GameManager.gd"
 [display]
 
 window/size/viewport_width=640
-window/size/viewport_height=640
+window/size/viewport_height=480
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 

--- a/scripts/core/Level.gd
+++ b/scripts/core/Level.gd
@@ -76,6 +76,7 @@ func _update_map_layout() -> void:
         playable_area_rect.size = grid_pixel_size
     if is_instance_valid(camera):
         camera.position = offset + grid_pixel_size * 0.5
+        camera.zoom = GameHelpers.calculate_zoom_to_fit(_current_grid_size, viewport_size)
         camera.limit_left = int(offset.x)
         camera.limit_top = int(offset.y)
         camera.limit_right = int(offset.x + grid_pixel_size.x)
@@ -154,3 +155,7 @@ func _get_array(source: Dictionary, key: String) -> Array:
 
 func get_level_name() -> String:
     return _level_name
+
+
+func get_grid_size() -> Vector2i:
+    return _current_grid_size

--- a/scripts/utils/constants.gd
+++ b/scripts/utils/constants.gd
@@ -2,6 +2,8 @@
 const TILE_SIZE := 64.0
 const GRID_WIDTH := 5
 const GRID_HEIGHT := 5
+const BASE_RESOLUTION := Vector2i(640, 480)
+const TARGET_ASPECT_RATIO := Vector2(4.0, 3.0)
 const PLAYER_START := Vector2i(1, 2)
 const BLOCK_START := Vector2i(2, 2)
 const ENEMY_START := Vector2i(3, 2)

--- a/scripts/utils/helpers.gd
+++ b/scripts/utils/helpers.gd
@@ -68,6 +68,22 @@ static func get_map_offset() -> Vector2:
     return _map_offset
 
 
+static func calculate_zoom_to_fit(grid_size: Vector2i, viewport_size: Vector2) -> Vector2:
+    """Calcula el zoom uniforme necesario para que el grid completo sea visible."""
+    var grid_pixel_size: Vector2 = Vector2(grid_size) * Consts.TILE_SIZE
+    if grid_pixel_size.x <= 0.0 or grid_pixel_size.y <= 0.0:
+        return Vector2.ONE
+    if viewport_size.x <= 0.0 or viewport_size.y <= 0.0:
+        return Vector2.ONE
+    var width_scale := viewport_size.x / grid_pixel_size.x
+    var height_scale := viewport_size.y / grid_pixel_size.y
+    var uniform_scale := min(width_scale, height_scale)
+    if uniform_scale <= 0.0:
+        return Vector2.ONE
+    var zoom_value := 1.0 / uniform_scale
+    return Vector2(zoom_value, zoom_value)
+
+
 static func calculate_center_offset(grid_size: Vector2i, viewport_size: Vector2) -> Vector2:
     """Calcula el offset necesario para centrar el mapa dentro del viewport."""
     var grid_pixel_size: Vector2 = Vector2(grid_size) * Consts.TILE_SIZE

--- a/tests/integration/sandbox_resolution.gd
+++ b/tests/integration/sandbox_resolution.gd
@@ -4,9 +4,9 @@ extends Node2D
 const LevelScene: PackedScene = preload("res://scenes/core/Level.tscn")
 
 @export var resolutions: Array[Vector2i] = [
-    Vector2i(640, 640),
+    Vector2i(640, 480),
     Vector2i(960, 720),
-    Vector2i(1280, 720),
+    Vector2i(1280, 960),
 ]
 
 var _resolution_index := 0

--- a/tests/integration/sandbox_scaling.gd
+++ b/tests/integration/sandbox_scaling.gd
@@ -1,0 +1,78 @@
+## SandboxScaling permite validar visualmente el escalado y centrado del área jugable.
+extends Node2D
+
+const LevelScene: PackedScene = preload("res://scenes/core/Level.tscn")
+const Consts = preload("res://scripts/utils/constants.gd")
+
+@export var level_files: Array[String] = [
+    "level_01.json",
+    "level_02.json",
+    "level_03.json",
+]
+
+@export var resolutions: Array[Vector2i] = [
+    Consts.BASE_RESOLUTION,
+    Vector2i(960, 720),
+    Vector2i(1280, 960),
+]
+
+var _level_index := 0
+var _resolution_index := 0
+var _level: Level
+var _last_info := ""
+
+@onready var info_label: Label = %InfoLabel
+
+func _ready() -> void:
+    set_process(true)
+    _load_current_level()
+    _apply_resolution(resolutions[_resolution_index])
+    _update_info_label()
+
+func _process(_delta: float) -> void:
+    _update_info_label()
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event.is_action_pressed("ui_right"):
+        _resolution_index = (_resolution_index + 1) % resolutions.size()
+        _apply_resolution(resolutions[_resolution_index])
+    elif event.is_action_pressed("ui_left"):
+        _resolution_index = (_resolution_index - 1 + resolutions.size()) % resolutions.size()
+        _apply_resolution(resolutions[_resolution_index])
+    elif event.is_action_pressed("ui_down"):
+        _level_index = (_level_index - 1 + level_files.size()) % level_files.size()
+        _load_current_level()
+    elif event.is_action_pressed("ui_up"):
+        _level_index = (_level_index + 1) % level_files.size()
+        _load_current_level()
+
+func _load_current_level() -> void:
+    if is_instance_valid(_level):
+        _level.queue_free()
+    _level = LevelScene.instantiate()
+    _level.level_file = Consts.LEVELS_DIR + level_files[_level_index]
+    add_child(_level)
+
+func _apply_resolution(size: Vector2i) -> void:
+    get_viewport().size = size
+
+func _update_info_label() -> void:
+    if not is_instance_valid(_level):
+        return
+    var viewport_size: Vector2 = _level.get_viewport_rect().size
+    var camera: Camera2D = _level.get_node_or_null("%Camera2D")
+    if camera == null:
+        return
+    var grid_size: Vector2i = _level.get_grid_size()
+    var info := "Nivel: %s (%dx%d) | Resolución: %dx%d | Zoom: %.2f" % [
+        _level.get_level_name(),
+        grid_size.x,
+        grid_size.y,
+        int(viewport_size.x),
+        int(viewport_size.y),
+        camera.zoom.x,
+    ]
+    if info == _last_info:
+        return
+    _last_info = info
+    info_label.text = info + "\nFlechas: Izq/Der resolución, Arriba/Abajo nivel"

--- a/tests/integration/sandbox_scaling.tscn
+++ b/tests/integration/sandbox_scaling.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/integration/sandbox_scaling.gd" id="1"]
+
+[node name="SandboxScaling" type="Node2D"]
+script = ExtResource("1")
+
+[node name="UI" type="CanvasLayer" parent="."]
+layer = 1
+
+[node name="InfoLabel" type="Label" parent="UI"]
+unique_name_in_owner = true
+anchors_preset = 0
+offset_left = 16.0
+offset_top = 16.0
+text = "Nivel: - | Resolución: 0x0 | Zoom: 0.00\nFlechas: Izq/Der resolución, Arriba/Abajo nivel"

--- a/tests/unit/test_aspect_ratio.gd
+++ b/tests/unit/test_aspect_ratio.gd
@@ -1,0 +1,46 @@
+## TestAspectRatio valida la configuración de resolución y el escalado uniforme del nivel.
+extends Node
+
+const Consts = preload("res://scripts/utils/constants.gd")
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+
+func run_tests() -> Array:
+    return [
+        _test_project_settings_match_constants(),
+        _test_zoom_respects_viewport_limits(),
+    ]
+
+func _test_project_settings_match_constants() -> Dictionary:
+    var base_resolution: Vector2i = Consts.BASE_RESOLUTION
+    var width := int(ProjectSettings.get_setting("display/window/size/viewport_width", 0))
+    var height := int(ProjectSettings.get_setting("display/window/size/viewport_height", 0))
+    var aspect_setting := String(ProjectSettings.get_setting("display/window/stretch/aspect", ""))
+    var mode_setting := String(ProjectSettings.get_setting("display/window/stretch/mode", ""))
+    var target_ratio := Consts.TARGET_ASPECT_RATIO.x / Consts.TARGET_ASPECT_RATIO.y if Consts.TARGET_ASPECT_RATIO.y != 0.0 else 1.0
+    var base_ratio := float(base_resolution.x) / float(base_resolution.y) if base_resolution.y != 0 else 1.0
+    var passed := width == base_resolution.x
+        and height == base_resolution.y
+        and is_equal_approx(base_ratio, target_ratio)
+        and aspect_setting == "keep"
+        and mode_setting == "2d"
+    return {
+        "name": "La resolución base y el aspecto coinciden con las constantes del proyecto",
+        "passed": passed,
+    }
+
+func _test_zoom_respects_viewport_limits() -> Dictionary:
+    var grid_size := Vector2i(13, 11)
+    var base_resolution := Consts.BASE_RESOLUTION
+    var viewport_size := Vector2(base_resolution.x, base_resolution.y) * 2.0
+    var zoom := GameHelpers.calculate_zoom_to_fit(grid_size, viewport_size)
+    var uniform := is_equal_approx(zoom.x, zoom.y)
+    var zoom_value := zoom.x if zoom.x != 0.0 else 1.0
+    var scale := 1.0 / zoom_value
+    var grid_pixel_size := Vector2(grid_size) * Consts.TILE_SIZE
+    var scaled_size := grid_pixel_size * scale
+    var fits_width := scaled_size.x <= viewport_size.x + 0.5
+    var fits_height := scaled_size.y <= viewport_size.y + 0.5
+    return {
+        "name": "El cálculo de zoom es uniforme y mantiene el nivel dentro del viewport",
+        "passed": uniform and fits_width and fits_height,
+    }

--- a/tests/unit/test_camera_center.gd
+++ b/tests/unit/test_camera_center.gd
@@ -1,0 +1,67 @@
+## TestCameraCenter verifica que la cámara se mantenga centrada tras cambios de viewport.
+extends Node
+
+const LevelScene: PackedScene = preload("res://scenes/core/Level.tscn")
+const Consts = preload("res://scripts/utils/constants.gd")
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+
+func run_tests() -> Array:
+    return [
+        await _test_camera_repositions_on_resize(),
+        await _test_camera_zoom_matches_helper(),
+    ]
+
+func _test_camera_repositions_on_resize() -> Dictionary:
+    var previous_bounds: Rect2i = GameHelpers.get_map_bounds()
+    var previous_offset: Vector2 = GameHelpers.get_map_offset()
+    var level: Level = LevelScene.instantiate()
+    add_child(level)
+    await get_tree().process_frame
+    var viewport: Viewport = level.get_viewport()
+    var original_size: Vector2i = viewport.size
+    viewport.size = Vector2i(960, 720)
+    await get_tree().process_frame
+    await get_tree().process_frame
+    var bounds: Rect2i = GameHelpers.get_map_bounds()
+    var grid_pixel_size: Vector2 = Vector2(bounds.size) * Consts.TILE_SIZE
+    var offset: Vector2 = GameHelpers.get_map_offset()
+    var camera: Camera2D = level.get_node("%Camera2D")
+    var expected_position: Vector2 = offset + grid_pixel_size * 0.5
+    var passed := camera.position.is_equal_approx(expected_position)
+    viewport.size = original_size
+    await get_tree().process_frame
+    level.queue_free()
+    await get_tree().process_frame
+    GameHelpers.set_map_bounds(previous_bounds)
+    GameHelpers.set_map_offset(previous_offset)
+    return {
+        "name": "La cámara permanece centrada tras redimensionar el viewport",
+        "passed": passed,
+    }
+
+func _test_camera_zoom_matches_helper() -> Dictionary:
+    var previous_bounds: Rect2i = GameHelpers.get_map_bounds()
+    var previous_offset: Vector2 = GameHelpers.get_map_offset()
+    var level: Level = LevelScene.instantiate()
+    add_child(level)
+    await get_tree().process_frame
+    var viewport: Viewport = level.get_viewport()
+    var original_size: Vector2i = viewport.size
+    viewport.size = Vector2i(1280, 960)
+    await get_tree().process_frame
+    await get_tree().process_frame
+    var bounds: Rect2i = GameHelpers.get_map_bounds()
+    var viewport_size: Vector2 = level.get_viewport_rect().size
+    var expected_zoom: Vector2 = GameHelpers.calculate_zoom_to_fit(bounds.size, viewport_size)
+    var camera: Camera2D = level.get_node("%Camera2D")
+    var passed := camera.zoom.is_equal_approx(expected_zoom)
+    viewport.size = original_size
+    await get_tree().process_frame
+    level.queue_free()
+    await get_tree().process_frame
+    GameHelpers.set_map_bounds(previous_bounds)
+    GameHelpers.set_map_offset(previous_offset)
+    return {
+        "name": "El zoom de la cámara coincide con el cálculo de GameHelpers",
+        "passed": passed,
+    }


### PR DESCRIPTION
## Summary
- switch the project to a 4:3 base resolution and update the level camera to compute a uniform zoom based on the viewport
- expose the level grid size and extend helpers with a zoom calculator used by the new scaling logic
- add unit and integration coverage for the camera centering/aspect ratio and provide a sandbox scene for visual checks

## Testing
- not run (Godot CLI unavailable)

------
https://chatgpt.com/codex/tasks/task_e_68dd4bf2d01c8330b78df363296e696f