### PR TITLE
Implement level transition flow and HUD messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
 - [x] Implementación de niveles originales de Don’t Pull (Capcom)
 - [x] Implementación de mecánicas/gameplay originales de Don’t Pull (Capcom)
 - [x] Ajuste de resolución, escalado y centrado del área jugable
-- [ ] Sistema de transición de niveles (pasar al siguiente al derrotar enemigos)
+- [x] Sistema de transición de niveles (pasar al siguiente al derrotar enemigos)
 - [ ] Sistema de puntuación arcade y tabla de récords (High Score)
 - [ ] Hooks de música y efectos de sonido (dummy)
 - [ ] Animaciones retro (dummy)

--- a/levels/level_transition_sandbox.json
+++ b/levels/level_transition_sandbox.json
@@ -1,0 +1,14 @@
+{
+    "name": "Sandbox-Transition",
+    "grid_size": {"width": 7, "height": 5},
+    "player": {"start": [1, 2]},
+    "blocks": [
+        [2, 2],
+        [3, 2],
+        [3, 3]
+    ],
+    "enemies": [
+        {"type": "random", "start": [5, 2]}
+    ],
+    "power_ups": []
+}

--- a/scenes/core/HUD.tscn
+++ b/scenes/core/HUD.tscn
@@ -60,3 +60,20 @@ text = "Vidas:"
 [node name="LivesValue" type="Label" parent="Root/LivesContainer"]
 unique_name_in_owner = true
 text = "3"
+
+[node name="LevelMessage" type="Label" parent="Root"]
+unique_name_in_owner = true
+visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -140.0
+margin_top = -32.0
+margin_right = 140.0
+margin_bottom = 32.0
+horizontal_alignment = 1
+vertical_alignment = 1
+theme_override_colors/font_color = Color(1, 0.890196, 0.356863, 1)
+theme_override_font_sizes/font_size = 42
+text = "LEVEL CLEAR!"

--- a/scripts/core/GameManager.gd
+++ b/scripts/core/GameManager.gd
@@ -5,17 +5,40 @@ const Consts = preload("res://scripts/utils/constants.gd")
 signal score_changed(new_score: int)
 signal lives_changed(new_lives: int)
 signal level_started(level_name: String)
+signal level_cleared(level_name: String)
+signal level_transition_queued(next_level_file: String)
 signal game_over()
 var _player: Player
 var _score := 0
 var _lives := Consts.START_LIVES
 var _enemies: Array[Enemy] = []
 var _current_level_name: String = ""
+var _current_level_file: String = ""
+var _level_sequence: Array = Consts.LEVEL_SEQUENCE.duplicate()
+var _current_level_index := 0
+var _queued_level_file: String = Consts.DEFAULT_LEVEL_FILE
+var _is_transitioning := false
 func _ready() -> void:
     """Emite el estado inicial al arrancar el autoload."""
     get_tree().scene_changed.connect(_on_scene_changed)
     score_changed.emit(_score)
     lives_changed.emit(_lives)
+    _queued_level_file = _get_default_level_file()
+
+func start_new_game() -> void:
+    """Reinicia puntuación, vidas y carga el primer nivel de la secuencia."""
+    _score = 0
+    _lives = Consts.START_LIVES
+    _current_level_name = ""
+    _current_level_file = ""
+    _is_transitioning = false
+    _enemies.clear()
+    score_changed.emit(_score)
+    lives_changed.emit(_lives)
+    _queued_level_file = _get_default_level_file()
+    var tree := get_tree()
+    if tree:
+        tree.change_scene_to_file(Consts.LEVEL_SCENE_PATH)
 
 func register_player(player: Player) -> void:
     """Guarda la referencia del jugador activo."""
@@ -38,8 +61,16 @@ func set_lives(value: int) -> void:
     if _lives <= 0:
         game_over.emit()
 
-func start_level(level_name: String = "") -> void:
+func start_level(level_name: String = "", level_file: String = "") -> void:
     """Propaga el inicio del nivel actual al HUD."""
+    var normalized_file := _normalize_level_file(level_file)
+    if normalized_file != "":
+        _current_level_file = normalized_file
+        _queued_level_file = normalized_file
+    elif _current_level_file == "":
+        _current_level_file = _normalize_level_file(_queued_level_file)
+    _is_transitioning = false
+    _update_current_level_index()
     var resolved_name := level_name.strip_edges()
     if resolved_name == "":
         return
@@ -62,6 +93,8 @@ func on_enemy_defeated(enemy: Enemy) -> void:
     """Elimina la referencia del enemigo y suma score."""
     _enemies.erase(enemy)
     add_score(Consts.ENEMY_SCORE)
+    if _enemies.is_empty():
+        _handle_level_cleared()
 
 func on_player_defeated() -> void:
     """Reduce las vidas del jugador y gestiona el reinicio o fin de partida."""
@@ -81,6 +114,10 @@ func return_to_menu() -> void:
     _score = 0
     _lives = Consts.START_LIVES
     _current_level_name = ""
+    _current_level_file = ""
+    _queued_level_file = _get_default_level_file()
+    _is_transitioning = false
+    _enemies.clear()
     score_changed.emit(_score)
     lives_changed.emit(_lives)
     get_tree().change_scene_to_file(Consts.MAIN_MENU_SCENE_PATH)
@@ -97,6 +134,70 @@ func _on_scene_changed(new_scene: Node) -> void:
     """Detecta cambios de escena para iniciar niveles automáticamente."""
     if new_scene and new_scene.scene_file_path == Consts.LEVEL_SCENE_PATH:
         var level_name := ""
+        var level_file := ""
         if new_scene.has_method("get_level_name"):
             level_name = String(new_scene.call("get_level_name"))
-        start_level(level_name)
+        if new_scene.has_method("get_level_file"):
+            level_file = String(new_scene.call("get_level_file"))
+        start_level(level_name, level_file)
+
+func get_queued_level_file() -> String:
+    """Devuelve el archivo configurado para cargarse en el siguiente nivel."""
+    return _queued_level_file
+
+func _handle_level_cleared() -> void:
+    """Cola la transición al siguiente nivel cuando no quedan enemigos."""
+    if _is_transitioning:
+        return
+    level_cleared.emit(_current_level_name)
+    var next_level_file := _get_next_level_file()
+    if next_level_file == "":
+        _is_transitioning = false
+        return
+    _queued_level_file = next_level_file
+    level_transition_queued.emit(_queued_level_file)
+    _is_transitioning = true
+    var tree := get_tree()
+    if tree == null:
+        return
+    await tree.create_timer(Consts.LEVEL_TRANSITION_DELAY).timeout
+    if _queued_level_file != next_level_file:
+        return
+    tree.change_scene_to_file(Consts.LEVEL_SCENE_PATH)
+
+func _get_next_level_file() -> String:
+    """Obtiene el siguiente archivo de nivel según la secuencia configurada."""
+    if _level_sequence.is_empty():
+        return _current_level_file
+    var current_index := _current_level_index
+    if current_index < 0 or current_index >= _level_sequence.size():
+        current_index = 0
+    var next_index := (current_index + 1) % _level_sequence.size()
+    return String(_level_sequence[next_index])
+
+func _get_default_level_file() -> String:
+    """Devuelve el primer archivo de la secuencia o el nivel por defecto."""
+    if _level_sequence.is_empty():
+        return Consts.DEFAULT_LEVEL_FILE
+    return String(_level_sequence[0])
+
+func _normalize_level_file(path: String) -> String:
+    """Normaliza la ruta del nivel para trabajar solo con el nombre del archivo."""
+    if path == "":
+        return ""
+    var levels_dir := Consts.LEVELS_DIR
+    if path.begins_with(levels_dir):
+        return path.substr(levels_dir.length())
+    if path.begins_with("res://") and path.find(levels_dir) != -1:
+        var start_index := path.find(levels_dir) + levels_dir.length()
+        return path.substr(start_index)
+    return path
+
+func _update_current_level_index() -> void:
+    """Sincroniza el índice del nivel actual según la secuencia declarada."""
+    if _level_sequence.is_empty():
+        _current_level_file = _normalize_level_file(_current_level_file)
+        _current_level_index = 0
+        return
+    var index := _level_sequence.find(_current_level_file)
+    _current_level_index = index if index != -1 else 0

--- a/scripts/core/HUD.gd
+++ b/scripts/core/HUD.gd
@@ -9,6 +9,7 @@ signal lives_updated(new_lives: int)
 @onready var lives_label: Label = %LivesValue
 @onready var level_label: Label = %LevelValue
 @onready var timer_label: Label = %TimerLabel
+@onready var message_label: Label = %LevelMessage
 
 var _is_timer_running := false
 var _elapsed_time := 0.0
@@ -18,9 +19,11 @@ func _ready() -> void:
     """Conecta el HUD al GameManager y muestra valores iniciales."""
     set_process(true)
     timer_label.text = _format_time(0.0)
+    _hide_level_message()
     GameManager.score_changed.connect(_on_score_changed)
     GameManager.lives_changed.connect(_on_lives_changed)
     GameManager.level_started.connect(_on_level_started)
+    GameManager.level_cleared.connect(_on_level_cleared)
     GameManager.game_over.connect(_on_game_over)
     GameManager.register_hud(self)
 
@@ -52,11 +55,18 @@ func _on_level_started(level_name: String) -> void:
     _elapsed_time = 0.0
     timer_label.text = _format_time(_elapsed_time)
     _is_timer_running = true
+    _hide_level_message()
+
+
+func _on_level_cleared(_level_name: String) -> void:
+    """Muestra un mensaje temporal cuando el nivel ha sido completado."""
+    _show_level_message("LEVEL CLEAR!")
 
 
 func _on_game_over() -> void:
     """Detiene el temporizador cuando el juego termina."""
     _is_timer_running = false
+    _show_level_message("GAME OVER")
 
 
 func _format_time(time_seconds: float) -> String:
@@ -65,3 +75,12 @@ func _format_time(time_seconds: float) -> String:
     var minutes := total_seconds / 60
     var seconds := total_seconds % 60
     return "%02d:%02d" % [minutes, seconds]
+
+
+func _show_level_message(text: String) -> void:
+    message_label.text = text
+    message_label.visible = true
+
+
+func _hide_level_message() -> void:
+    message_label.visible = false

--- a/scripts/core/Level.gd
+++ b/scripts/core/Level.gd
@@ -19,6 +19,7 @@ const PowerUpScene: PackedScene = preload("res://scenes/entities/PowerUp.tscn")
 @onready var camera: Camera2D = %Camera2D
 var _current_grid_size: Vector2i = Vector2i(Consts.GRID_WIDTH, Consts.GRID_HEIGHT)
 var _level_name: String = ""
+var _current_level_file: String = ""
 
 func _ready() -> void:
     """Carga los datos del nivel y posiciona entidades según el layout."""
@@ -33,10 +34,14 @@ func _on_viewport_resized() -> void:
     _update_map_layout()
 
 func _load_level_data() -> Dictionary:
-    var path: String = level_file if level_file != "" else LevelLoader.get_default_level_path()
+    var path: String = level_file if level_file != "" else GameManager.get_queued_level_file()
+    if path == "":
+        path = LevelLoader.get_default_level_path()
+    _current_level_file = path
     var data: Dictionary = LevelLoader.load_level(path)
     if not data.is_empty():
         return data
+    _current_level_file = Consts.DEFAULT_LEVEL_FILE
     return {
         "name": name,
         "grid_size": {"width": Consts.GRID_WIDTH, "height": Consts.GRID_HEIGHT},
@@ -60,7 +65,7 @@ func _apply_level_data(data: Dictionary) -> void:
     _spawn_power_ups(_get_array(data, "power_ups"))
     hud.offset = Vector2.ZERO
     name = _level_name if _level_name != "" else name
-    GameManager.start_level(_level_name)
+    GameManager.start_level(_level_name, _current_level_file)
 
 func _update_map_layout() -> void:
     var viewport_size: Vector2 = get_viewport_rect().size
@@ -159,3 +164,7 @@ func get_level_name() -> String:
 
 func get_grid_size() -> Vector2i:
     return _current_grid_size
+
+
+func get_level_file() -> String:
+    return _current_level_file

--- a/scripts/core/MainMenu.gd
+++ b/scripts/core/MainMenu.gd
@@ -2,8 +2,6 @@
 extends Control
 class_name MainMenu
 
-const Consts = preload("res://scripts/utils/constants.gd")
-
 @onready var start_button: Button = %StartButton
 
 func _ready() -> void:
@@ -13,4 +11,4 @@ func _ready() -> void:
 
 func _on_start_button_pressed() -> void:
     """Carga la escena del nivel principal."""
-    get_tree().change_scene_to_file(Consts.LEVEL_SCENE_PATH)
+    GameManager.start_new_game()

--- a/scripts/utils/constants.gd
+++ b/scripts/utils/constants.gd
@@ -20,6 +20,12 @@ const LEVEL_SCENE_PATH := "res://scenes/core/Level.tscn"
 const MAIN_MENU_SCENE_PATH := "res://scenes/core/MainMenu.tscn"
 const LEVELS_DIR := "res://levels/"
 const DEFAULT_LEVEL_FILE := "level_01.json"
+const LEVEL_SEQUENCE := [
+    "level_01.json",
+    "level_02.json",
+    "level_03.json",
+]
+const LEVEL_TRANSITION_DELAY := 1.5
 const POWER_UP_DEFAULT_SCORE := 50
 const POWER_UP_SCORES := {
     "fruit": 100,

--- a/tests/integration/sandbox_level_transition.gd
+++ b/tests/integration/sandbox_level_transition.gd
@@ -1,0 +1,15 @@
+## SandboxLevelTransition muestra el flujo de cambio de nivel al eliminar al último enemigo.
+extends Node2D
+
+@onready var level: Level = %Level
+
+func _ready() -> void:
+    """Derrota al único enemigo tras un breve retraso para observar la transición."""
+    _clear_late()
+
+
+func _clear_late() -> void:
+    await get_tree().create_timer(1.0).timeout
+    for enemy: Node in get_tree().get_nodes_in_group("enemies"):
+        if enemy.has_method("set_dead_state"):
+            enemy.set_dead_state()

--- a/tests/integration/sandbox_level_transition.tscn
+++ b/tests/integration/sandbox_level_transition.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/core/Level.tscn" id="1"]
+[ext_resource type="Script" path="res://tests/integration/sandbox_level_transition.gd" id="2"]
+
+[node name="LevelTransitionSandbox" type="Node2D"]
+script = ExtResource("2")
+
+[node name="Level" parent="." instance=ExtResource("1")]
+unique_name_in_owner = true
+level_file = "level_transition_sandbox.json"

--- a/tests/unit/test_hud.gd
+++ b/tests/unit/test_hud.gd
@@ -8,6 +8,7 @@ class GameManagerStub:
     signal score_changed(new_score: int)
     signal lives_changed(new_lives: int)
     signal level_started(level_name: String)
+    signal level_cleared(level_name: String)
     signal game_over()
     var registered_hud: HUD
 

--- a/tests/unit/test_level_transition.gd
+++ b/tests/unit/test_level_transition.gd
@@ -1,0 +1,51 @@
+## TestLevelTransition valida el flujo de transición entre niveles del GameManager.
+extends Node
+
+const GameManagerScript = preload("res://scripts/core/GameManager.gd")
+const EnemyScript = preload("res://scripts/entities/Enemy.gd")
+const Consts = preload("res://scripts/utils/constants.gd")
+
+func run_tests() -> Array:
+    """Ejecuta los casos para el sistema de transición de niveles."""
+    return [
+        _test_queue_next_level_when_enemies_cleared(),
+        _test_sequence_wraps_back_to_first_level(),
+        _test_start_new_game_resets_level_queue(),
+    ]
+
+
+func _test_queue_next_level_when_enemies_cleared() -> Dictionary:
+    var manager: GameManager = GameManagerScript.new()
+    manager.start_level("Orchard-01", "level_01.json")
+    var enemy_a: Enemy = EnemyScript.new()
+    var enemy_b: Enemy = EnemyScript.new()
+    manager.register_enemy(enemy_a)
+    manager.register_enemy(enemy_b)
+    manager.on_enemy_defeated(enemy_a)
+    manager.on_enemy_defeated(enemy_b)
+    return {
+        "name": "GameManager cola el siguiente nivel al derrotar a todos los enemigos",
+        "passed": manager.get_queued_level_file() == Consts.LEVEL_SEQUENCE[1],
+    }
+
+
+func _test_sequence_wraps_back_to_first_level() -> Dictionary:
+    var manager: GameManager = GameManagerScript.new()
+    manager.start_level("Orchard-03", "level_03.json")
+    var solo_enemy: Enemy = EnemyScript.new()
+    manager.register_enemy(solo_enemy)
+    manager.on_enemy_defeated(solo_enemy)
+    return {
+        "name": "La secuencia vuelve al primer nivel tras el último archivo",
+        "passed": manager.get_queued_level_file() == Consts.LEVEL_SEQUENCE[0],
+    }
+
+
+func _test_start_new_game_resets_level_queue() -> Dictionary:
+    var manager: GameManager = GameManagerScript.new()
+    manager.start_level("Orchard-02", "level_02.json")
+    manager.start_new_game()
+    return {
+        "name": "StartNewGame prepara el primer nivel de la secuencia",
+        "passed": manager.get_queued_level_file() == Consts.LEVEL_SEQUENCE[0],
+    }


### PR DESCRIPTION
## Summary
- queue level progression in GameManager with a reusable start_new_game flow and transition delay
- align Level, HUD, and MainMenu with the new sequencing to show a "Level Clear" message and preserve the next level to load
- add a sandbox level plus unit/integration coverage for the transition pipeline and mark the README task complete

## Testing
- Not run (Godot CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dd5846fa7c8330aa9c12034685c211