### PR TITLE
Implement persistent high score table and submission UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
 - [x] Implementación de mecánicas/gameplay originales de Don’t Pull (Capcom)
 - [x] Ajuste de resolución, escalado y centrado del área jugable
 - [x] Sistema de transición de niveles (pasar al siguiente al derrotar enemigos)
-- [ ] Sistema de puntuación arcade y tabla de récords (High Score)
+- [x] Sistema de puntuación arcade y tabla de récords (High Score)
 - [ ] Hooks de música y efectos de sonido (dummy)
 - [ ] Animaciones retro (dummy)
 - [ ] Pantalla de introducción / attract mode

--- a/scenes/core/HUD.tscn
+++ b/scenes/core/HUD.tscn
@@ -17,6 +17,21 @@ margin_top = 16.0
 text = "Nivel"
 vertical_alignment = 1
 
+[node name="HighScoreContainer" type="HBoxContainer" parent="Root"]
+anchor_left = 0.5
+anchor_right = 0.5
+margin_left = -160.0
+margin_top = 48.0
+margin_right = 160.0
+alignment = 1
+
+[node name="HighScoreTitle" type="Label" parent="Root/HighScoreContainer"]
+text = "High Score:"
+
+[node name="HighScoreValue" type="Label" parent="Root/HighScoreContainer"]
+unique_name_in_owner = true
+text = "0"
+
 [node name="ScoreContainer" type="HBoxContainer" parent="Root"]
 anchor_left = 1.0
 anchor_right = 1.0
@@ -77,3 +92,43 @@ vertical_alignment = 1
 theme_override_colors/font_color = Color(1, 0.890196, 0.356863, 1)
 theme_override_font_sizes/font_size = 42
 text = "LEVEL CLEAR!"
+
+[node name="HighScorePanel" type="Panel" parent="Root"]
+unique_name_in_owner = true
+visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -140.0
+margin_top = -96.0
+margin_right = 140.0
+margin_bottom = 96.0
+
+[node name="PanelContainer" type="MarginContainer" parent="Root/HighScorePanel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Root/HighScorePanel/PanelContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+alignment = 1
+theme_override_constants/separation = 12
+
+[node name="HighScoreMessage" type="Label" parent="Root/HighScorePanel/PanelContainer/VBoxContainer"]
+text = "INGRESA TUS INICIALES"
+horizontal_alignment = 1
+
+[node name="InitialsInput" type="LineEdit" parent="Root/HighScorePanel/PanelContainer/VBoxContainer"]
+unique_name_in_owner = true
+max_length = 3
+horizontal_alignment = 1
+caret_blink = true
+
+[node name="SubmitInitialsButton" type="Button" parent="Root/HighScorePanel/PanelContainer/VBoxContainer"]
+unique_name_in_owner = true
+text = "Guardar"

--- a/scenes/core/MainMenu.tscn
+++ b/scenes/core/MainMenu.tscn
@@ -27,3 +27,15 @@ horizontal_alignment = 1
 unique_name_in_owner = true
 layout_mode = 2
 text = "Iniciar"
+
+[node name="HighScoreTitle" type="Label" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "High Scores"
+horizontal_alignment = 1
+
+[node name="HighScoreList" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = false
+scroll_active = false

--- a/scripts/core/HighScoreService.gd
+++ b/scripts/core/HighScoreService.gd
@@ -1,0 +1,121 @@
+## HighScoreService gestiona la tabla de récords persistente del juego.
+extends Object
+class_name HighScoreService
+
+const SAVE_PATH := "user://scores.json"
+const MAX_ENTRIES := 10
+const INITIALS_LENGTH := 3
+
+static var _scores: Array[Dictionary] = []
+static var _is_loaded := false
+
+
+static func get_high_scores() -> Array[Dictionary]:
+    """Devuelve una copia de las puntuaciones almacenadas de mayor a menor."""
+    _ensure_loaded()
+    return _scores.duplicate(true)
+
+
+static func get_high_score_value() -> int:
+    """Devuelve la puntuación más alta registrada."""
+    _ensure_loaded()
+    if _scores.is_empty():
+        return 0
+    return int(_scores[0].get("score", 0))
+
+
+static func submit_score(initials: String, score: int) -> Array[Dictionary]:
+    """Registra una nueva puntuación y devuelve la tabla actualizada."""
+    _ensure_loaded()
+    if score <= 0:
+        return get_high_scores()
+    var entry := _create_entry(initials, score)
+    _scores.append(entry)
+    _sort_scores()
+    if _scores.size() > MAX_ENTRIES:
+        _scores.resize(MAX_ENTRIES)
+    _save_scores()
+    return get_high_scores()
+
+
+static func clear_scores(remove_file := true) -> void:
+    """Elimina todas las puntuaciones registradas."""
+    _scores.clear()
+    _is_loaded = true
+    if remove_file:
+        _remove_save_file()
+    else:
+        _save_scores()
+
+
+static func _ensure_loaded() -> void:
+    if _is_loaded:
+        return
+    _load_scores_from_disk()
+    _is_loaded = true
+
+
+static func _create_entry(initials: String, score: int) -> Dictionary:
+    return {
+        "initials": _sanitize_initials(initials),
+        "score": int(score),
+        "timestamp": Time.get_unix_time_from_system(),
+    }
+
+
+static func _sanitize_initials(initials: String) -> String:
+    var trimmed := initials.strip_edges().to_upper()
+    if trimmed == "":
+        trimmed = "AAA"
+    if trimmed.length() > INITIALS_LENGTH:
+        trimmed = trimmed.substr(0, INITIALS_LENGTH)
+    while trimmed.length() < INITIALS_LENGTH:
+        trimmed += "A"
+    return trimmed
+
+
+static func _sort_scores() -> void:
+    _scores.sort_custom(func(a: Dictionary, b: Dictionary):
+        var score_a := int(a.get("score", 0))
+        var score_b := int(b.get("score", 0))
+        if score_a == score_b:
+            return int(a.get("timestamp", 0)) < int(b.get("timestamp", 0))
+        return score_a > score_b
+    )
+
+
+static func _load_scores_from_disk() -> void:
+    _scores.clear()
+    if not FileAccess.file_exists(SAVE_PATH):
+        return
+    var file := FileAccess.open(SAVE_PATH, FileAccess.READ)
+    if file == null:
+        return
+    var content := file.get_as_text()
+    var data := JSON.parse_string(content)
+    if data == null:
+        return
+    if data is Array:
+        for element in data:
+            if element is Dictionary and element.has("score"):
+                var entry := {
+                    "initials": _sanitize_initials(String(element.get("initials", "AAA"))),
+                    "score": int(element.get("score", 0)),
+                    "timestamp": int(element.get("timestamp", 0)),
+                }
+                _scores.append(entry)
+    _sort_scores()
+
+
+static func _save_scores() -> void:
+    var file := FileAccess.open(SAVE_PATH, FileAccess.WRITE)
+    if file == null:
+        return
+    file.store_string(JSON.stringify(_scores, "  "))
+
+
+static func _remove_save_file() -> void:
+    if not FileAccess.file_exists(SAVE_PATH):
+        return
+    var absolute_path := ProjectSettings.globalize_path(SAVE_PATH)
+    DirAccess.remove_absolute(absolute_path)

--- a/scripts/core/MainMenu.gd
+++ b/scripts/core/MainMenu.gd
@@ -3,12 +3,32 @@ extends Control
 class_name MainMenu
 
 @onready var start_button: Button = %StartButton
+@onready var high_score_list: RichTextLabel = %HighScoreList
 
 func _ready() -> void:
     """Conecta señales del botón de inicio."""
     start_button.pressed.connect(_on_start_button_pressed)
+    GameManager.high_score_changed.connect(_on_high_score_changed)
+    _refresh_high_scores()
 
 
 func _on_start_button_pressed() -> void:
     """Carga la escena del nivel principal."""
     GameManager.start_new_game()
+
+
+func _on_high_score_changed(_value: int) -> void:
+    _refresh_high_scores()
+
+
+func _refresh_high_scores() -> void:
+    var entries := GameManager.get_high_scores()
+    var lines: Array[String] = []
+    for index in entries.size():
+        var entry := entries[index]
+        var initials := String(entry.get("initials", "AAA"))
+        var score := int(entry.get("score", 0))
+        lines.append("%d. %s - %d" % [index + 1, initials, score])
+    if lines.is_empty():
+        lines.append("No hay récords todavía")
+    high_score_list.text = "\n".join(lines)

--- a/tests/integration/sandbox_high_score.gd
+++ b/tests/integration/sandbox_high_score.gd
@@ -1,0 +1,14 @@
+## SandboxHighScore carga la tabla de récords con datos de ejemplo.
+extends Node2D
+
+const HighScoreService = preload("res://scripts/core/HighScoreService.gd")
+const MainMenuScene: PackedScene = preload("res://scenes/core/MainMenu.tscn")
+
+func _ready() -> void:
+    """Inicializa puntuaciones de ejemplo y muestra el menú."""
+    HighScoreService.clear_scores()
+    HighScoreService.submit_score("AAA", 1200)
+    HighScoreService.submit_score("BBB", 900)
+    HighScoreService.submit_score("CCC", 750)
+    var menu := MainMenuScene.instantiate()
+    add_child(menu)

--- a/tests/integration/sandbox_high_score.tscn
+++ b/tests/integration/sandbox_high_score.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/integration/sandbox_high_score.gd" id="1"]
+
+[node name="SandboxHighScore" type="Node2D"]
+script = ExtResource("1")

--- a/tests/unit/test_high_score.gd
+++ b/tests/unit/test_high_score.gd
@@ -1,0 +1,44 @@
+## TestHighScore verifica la persistencia y orden de la tabla de récords.
+extends Node
+
+const HighScoreService = preload("res://scripts/core/HighScoreService.gd")
+
+func run_tests() -> Array:
+    HighScoreService.clear_scores()
+    var results := [
+        _test_submit_and_sort_scores(),
+        _test_max_entries_limit(),
+    ]
+    HighScoreService.clear_scores()
+    return results
+
+
+func _test_submit_and_sort_scores() -> Dictionary:
+    HighScoreService.clear_scores()
+    HighScoreService.submit_score("abc", 100)
+    HighScoreService.submit_score("XYZ", 50)
+    var scores := HighScoreService.get_high_scores()
+    var passed := scores.size() == 2
+        and scores[0].get("initials") == "ABC"
+        and scores[0].get("score") == 100
+        and scores[1].get("initials") == "XYZ"
+        and scores[1].get("score") == 50
+    return {
+        "name": "HighScoreService guarda y ordena puntuaciones en mayúsculas",
+        "passed": passed,
+    }
+
+
+func _test_max_entries_limit() -> Dictionary:
+    HighScoreService.clear_scores()
+    for index in 12:
+        var initials := "A%02d" % index
+        HighScoreService.submit_score(initials, index * 10)
+    var scores := HighScoreService.get_high_scores()
+    var passed := scores.size() == HighScoreService.MAX_ENTRIES
+        and scores[0].get("score") == 110
+        and scores[-1].get("score") == 20
+    return {
+        "name": "HighScoreService limita la tabla a las mejores 10 puntuaciones",
+        "passed": passed,
+    }

--- a/tests/unit/test_hud.gd
+++ b/tests/unit/test_hud.gd
@@ -10,10 +10,19 @@ class GameManagerStub:
     signal level_started(level_name: String)
     signal level_cleared(level_name: String)
     signal game_over()
+    signal high_score_changed(new_high_score: int)
     var registered_hud: HUD
+    var high_score_value := 0
+    var submitted_initials: Array[String] = []
 
     func register_hud(hud: HUD) -> void:
         registered_hud = hud
+
+    func get_high_score() -> int:
+        return high_score_value
+
+    func submit_final_score(initials: String) -> void:
+        submitted_initials.append(initials)
 
 
 func run_tests() -> Array:
@@ -21,12 +30,14 @@ func run_tests() -> Array:
     return [
         await _test_score_and_lives_update_labels(),
         await _test_level_timer_formats_and_stops(),
+        await _test_high_score_entry_panel(),
     ]
 
 
 func _test_score_and_lives_update_labels() -> Dictionary:
     var original_game_manager := GameManager
     var stub := GameManagerStub.new()
+    stub.high_score_value = 1200
     GameManager = stub
     add_child(stub)
     var hud: HUD = HUDScene.instantiate()
@@ -36,9 +47,18 @@ func _test_score_and_lives_update_labels() -> Dictionary:
     stub.lives_changed.emit(2)
     var score_label: Label = hud.get_node("Root/ScoreContainer/ScoreValue")
     var lives_label: Label = hud.get_node("Root/LivesContainer/LivesValue")
+    var high_score_label: Label = hud.get_node("Root/HighScoreContainer/HighScoreValue")
+    var initial_high_score := high_score_label.text
+    stub.high_score_value = 2000
+    stub.high_score_changed.emit(2000)
+    await get_tree().process_frame
     var result := {
-        "name": "HUD refleja las actualizaciones de score y vidas",
-        "passed": score_label.text == "450" and lives_label.text == "2" and stub.registered_hud == hud,
+        "name": "HUD refleja las actualizaciones de score, vidas y high score",
+        "passed": score_label.text == "450"
+            and lives_label.text == "2"
+            and stub.registered_hud == hud
+            and initial_high_score == "1200"
+            and high_score_label.text == "2000",
     }
     hud.queue_free()
     stub.queue_free()
@@ -70,6 +90,31 @@ func _test_level_timer_formats_and_stops() -> Dictionary:
             and running_level_name == "Nivel 1"
             and running_timer_text == "01:05"
             and stopped_timer_text == "01:05",
+    }
+    hud.queue_free()
+    stub.queue_free()
+    GameManager = original_game_manager
+    return result
+
+
+func _test_high_score_entry_panel() -> Dictionary:
+    var original_game_manager := GameManager
+    var stub := GameManagerStub.new()
+    GameManager = stub
+    add_child(stub)
+    var hud: HUD = HUDScene.instantiate()
+    add_child(hud)
+    await get_tree().process_frame
+    stub.game_over.emit()
+    await get_tree().process_frame
+    var panel: Panel = hud.get_node("Root/HighScorePanel")
+    var line_edit: LineEdit = hud.get_node("Root/HighScorePanel/PanelContainer/VBoxContainer/InitialsInput")
+    line_edit.text = "abc"
+    line_edit.emit_signal("text_submitted", line_edit.text)
+    await get_tree().process_frame
+    var result := {
+        "name": "HUD muestra panel de high score y envía iniciales",
+        "passed": panel.visible and stub.submitted_initials == ["ABC"],
     }
     hud.queue_free()
     stub.queue_free()


### PR DESCRIPTION
## Summary
- add a reusable HighScoreService that persists and sorts the arcade score table
- hook GameManager, HUD, and MainMenu into the service to display and submit high scores with initials entry
- cover the new behaviour with unit tests and a sandbox scene for manual verification

## Testing
- not run (Godot headless runner not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd5d8951f08330ab07c3a78056772c