### PR TITLE
Fix JSON parsing in HighScoreService

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ El objetivo es replicar mecánicas originales en grid, manteniendo arquitectura 
 - [x] Ajuste de resolución, escalado y centrado del área jugable
 - [x] Sistema de transición de niveles (pasar al siguiente al derrotar enemigos)
 - [x] Sistema de puntuación arcade y tabla de récords (High Score)
-- [ ] Corrección de parseo JSON en HighScoreService
+- [x] Corrección de parseo JSON en HighScoreService
 - [ ] Hooks de música y efectos de sonido (dummy)
 - [ ] Animaciones retro (dummy)
 - [ ] Pantalla de introducción / attract mode

--- a/scripts/core/HighScoreService.gd
+++ b/scripts/core/HighScoreService.gd
@@ -92,18 +92,26 @@ static func _load_scores_from_disk() -> void:
     if file == null:
         return
     var content := file.get_as_text()
-    var data := JSON.parse_string(content)
-    if data == null:
+    var json := JSON.new()
+    var parse_error := json.parse(content)
+    if parse_error != OK:
         return
-    if data is Array:
-        for element in data:
-            if element is Dictionary and element.has("score"):
-                var entry := {
-                    "initials": _sanitize_initials(String(element.get("initials", "AAA"))),
-                    "score": int(element.get("score", 0)),
-                    "timestamp": int(element.get("timestamp", 0)),
-                }
-                _scores.append(entry)
+    var data_variant := json.get_data()
+    if not (data_variant is Array):
+        return
+    var data: Array = data_variant
+    for element_variant in data:
+        if not (element_variant is Dictionary):
+            continue
+        var element: Dictionary = element_variant
+        if not element.has("score"):
+            continue
+        var entry := {
+            "initials": _sanitize_initials(String(element.get("initials", "AAA"))),
+            "score": int(element.get("score", 0)),
+            "timestamp": int(element.get("timestamp", 0)),
+        }
+        _scores.append(entry)
     _sort_scores()
 
 

--- a/tests/integration/sandbox_highscore_json.gd
+++ b/tests/integration/sandbox_highscore_json.gd
@@ -1,0 +1,33 @@
+## SandboxHighScoreJson verifica la lectura de archivos de récords desde JSON.
+extends Node2D
+
+const HighScoreService = preload("res://scripts/core/HighScoreService.gd")
+const MainMenuScene: PackedScene = preload("res://scenes/core/MainMenu.tscn")
+
+func _ready() -> void:
+    """Genera un archivo de récords y muestra el menú con los resultados."""
+    HighScoreService.clear_scores()
+    _write_sample_file()
+    _reset_cache()
+    HighScoreService.get_high_scores()
+    var menu := MainMenuScene.instantiate()
+    add_child(menu)
+
+
+func _write_sample_file() -> void:
+    var payload := [
+        {"initials": "AAA", "score": 2000, "timestamp": 1},
+        {"initials": "bbb", "score": 1500, "timestamp": 2},
+        {"initials": "CCC"},
+        "invalid",
+    ]
+    var file := FileAccess.open(HighScoreService.SAVE_PATH, FileAccess.WRITE)
+    if file == null:
+        return
+    file.store_string(JSON.stringify(payload, "  "))
+    file.close()
+
+
+func _reset_cache() -> void:
+    HighScoreService._scores.clear()
+    HighScoreService._is_loaded = false

--- a/tests/integration/sandbox_highscore_json.tscn
+++ b/tests/integration/sandbox_highscore_json.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/integration/sandbox_highscore_json.gd" id="1"]
+
+[node name="SandboxHighScoreJson" type="Node2D"]
+script = ExtResource("1")

--- a/tests/unit/test_highscore_json.gd
+++ b/tests/unit/test_highscore_json.gd
@@ -1,0 +1,80 @@
+## TestHighScoreJson valida la carga robusta de datos desde disco.
+extends Node
+
+const HighScoreService = preload("res://scripts/core/HighScoreService.gd")
+
+func run_tests() -> Array:
+    HighScoreService.clear_scores()
+    var results := [
+        _test_loads_scores_from_valid_json(),
+        _test_returns_empty_on_invalid_json(),
+        _test_ignores_entries_without_score(),
+    ]
+    HighScoreService.clear_scores()
+    return results
+
+
+func _test_loads_scores_from_valid_json() -> Dictionary:
+    var payload := [
+        {"initials": "abc", "score": 1200, "timestamp": 10},
+        {"initials": "XYZ", "score": 900, "timestamp": 20},
+    ]
+    _write_payload(payload)
+    _reset_cache()
+    var scores := HighScoreService.get_high_scores()
+    var passed := scores.size() == 2
+        and scores[0].get("initials") == "ABC"
+        and scores[0].get("score") == 1200
+        and scores[1].get("initials") == "XYZ"
+        and scores[1].get("score") == 900
+    return {
+        "name": "HighScoreService carga puntuaciones válidas desde JSON",
+        "passed": passed,
+    }
+
+
+func _test_returns_empty_on_invalid_json() -> Dictionary:
+    _write_raw("{ invalid json }")
+    _reset_cache()
+    var scores := HighScoreService.get_high_scores()
+    return {
+        "name": "HighScoreService ignora archivos JSON inválidos",
+        "passed": scores.is_empty(),
+    }
+
+
+func _test_ignores_entries_without_score() -> Dictionary:
+    var payload := [
+        {"initials": "AAA", "score": 500},
+        {"initials": "BBB"},
+        "not a dictionary",
+    ]
+    _write_payload(payload)
+    _reset_cache()
+    var scores := HighScoreService.get_high_scores()
+    var passed := scores.size() == 1 and scores[0].get("initials") == "AAA"
+    return {
+        "name": "HighScoreService descarta entradas sin score",
+        "passed": passed,
+    }
+
+
+func _write_payload(payload: Array) -> void:
+    var file := FileAccess.open(HighScoreService.SAVE_PATH, FileAccess.WRITE)
+    if file == null:
+        return
+    file.store_string(JSON.stringify(payload))
+    file.close()
+
+
+func _write_raw(content: String) -> void:
+    var file := FileAccess.open(HighScoreService.SAVE_PATH, FileAccess.WRITE)
+    if file == null:
+        return
+    file.store_string(content)
+    file.close()
+
+
+func _reset_cache() -> void:
+    HighScoreService._scores.clear()
+    HighScoreService._is_loaded = false


### PR DESCRIPTION
## Summary
- use the JSON API to parse the stored high score file with explicit typing and error checks
- add unit and integration coverage for loading valid and invalid high score data from disk
- mark the JSON parsing task as completed in the README checklist

## Testing
- godot --headless --run-tests *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8c83269883309cfeb6fedb7e4db1