### PR TITLE
Add audio manager hooks for placeholder music and SFX

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,9 @@ Clonar en Godot el juego arcade *Don’t Pull* (Capcom, 1991 dentro de Three Won
 - **Assets**
   - Spritesheets (placeholders o extraídos de ROM).
   - Audio SFX/Music (placeholders o libres de derechos).
+- **Audio Layer**
+  - Autoload `AudioManager` centraliza BGM y SFX dummy.
+  - Hooks independientes por evento de gameplay para facilitar sustitución por assets finales.
 - **Testing & Debug**
   - Logs de comportamiento (frame stepping).
   - Herramientas de replay simple.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -20,7 +20,7 @@
 - [x] Sistema de transición de niveles
 - [x] Sistema de puntuación arcade y tabla de récords (High Score)
 - [x] Corrección de parseo JSON en HighScoreService
-- [ ] Hooks de música y efectos de sonido (dummy)
+- [x] Hooks de música y efectos de sonido (dummy)
 - [ ] Animaciones retro (dummy)
 - [ ] Pantalla de introducción / attract mode
 - [ ] Balance y dificultad progresiva

--- a/project.godot
+++ b/project.godot
@@ -17,6 +17,7 @@ config/features=PackedStringArray("4.5")
 [autoload]
 
 GameManager="*res://scripts/core/GameManager.gd"
+AudioManager="*res://scripts/core/AudioManager.gd"
 
 [display]
 

--- a/scripts/core/AudioManager.gd
+++ b/scripts/core/AudioManager.gd
@@ -1,0 +1,122 @@
+## AudioManager centraliza la reproducción de música y efectos de sonido.
+extends Node
+class_name AudioManager
+
+const EVENT_BGM := "bgm"
+const EVENT_BLOCK_LAUNCH := "block_launch"
+const EVENT_BLOCK_DESTROY := "block_destroy"
+const EVENT_ENEMY_CRUSH := "enemy_crush"
+const EVENT_POWER_UP := "power_up"
+const EVENT_GAME_OVER := "game_over"
+
+var _players: Dictionary = {}
+
+func _ready() -> void:
+    """Crea los nodos de audio necesarios para los distintos eventos."""
+    _initialize_players()
+
+func play_bgm() -> void:
+    """Inicia la reproducción del BGM si hay un stream disponible."""
+    _ensure_players_ready()
+    var player: AudioStreamPlayer = _players.get(EVENT_BGM, null)
+    if player == null:
+        return
+    if player.playing:
+        return
+    player.play()
+
+func stop_bgm() -> void:
+    """Detiene la reproducción del BGM."""
+    _ensure_players_ready()
+    var player: AudioStreamPlayer = _players.get(EVENT_BGM, null)
+    if player == null:
+        return
+    if player.playing:
+        player.stop()
+
+func play_block_launch() -> void:
+    """Reproduce el efecto asociado al lanzamiento de bloque."""
+    _ensure_players_ready()
+    _restart_player(EVENT_BLOCK_LAUNCH)
+
+func play_block_destroy() -> void:
+    """Reproduce el efecto asociado a la destrucción de bloques."""
+    _ensure_players_ready()
+    _restart_player(EVENT_BLOCK_DESTROY)
+
+func play_enemy_crush() -> void:
+    """Reproduce el efecto al aplastar un enemigo."""
+    _ensure_players_ready()
+    _restart_player(EVENT_ENEMY_CRUSH)
+
+func play_power_up() -> void:
+    """Reproduce el efecto de recoger un power-up."""
+    _ensure_players_ready()
+    _restart_player(EVENT_POWER_UP)
+
+func play_game_over() -> void:
+    """Reproduce el efecto de Game Over."""
+    _ensure_players_ready()
+    _restart_player(EVENT_GAME_OVER)
+
+func set_player_override(event_name: String, player: AudioStreamPlayer) -> void:
+    """Permite sustituir un reproductor para pruebas o configuraciones especiales."""
+    _ensure_players_ready()
+    if not _players.has(event_name):
+        return
+    var current: AudioStreamPlayer = _players[event_name]
+    if is_instance_valid(current):
+        current.queue_free()
+    var target_name := current.name if current else StringName(event_name + "_player")
+    player.name = target_name
+    add_child(player)
+    _players[event_name] = player
+
+func get_player(event_name: String) -> AudioStreamPlayer:
+    """Devuelve el reproductor asociado a un evento."""
+    _ensure_players_ready()
+    return _players.get(event_name, null)
+
+func _restart_player(event_name: String) -> void:
+    var player: AudioStreamPlayer = _players.get(event_name, null)
+    if player == null:
+        return
+    if player.playing:
+        player.stop()
+    player.play()
+
+func _ensure_player(node_name: String) -> AudioStreamPlayer:
+    var player: AudioStreamPlayer = AudioStreamPlayer.new()
+    player.name = node_name
+    add_child(player)
+    return player
+
+func _initialize_players() -> void:
+    if not _players.is_empty():
+        return
+    _players = {
+        EVENT_BGM: _ensure_player("BGMPlayer"),
+        EVENT_BLOCK_LAUNCH: _ensure_player("BlockLaunchPlayer"),
+        EVENT_BLOCK_DESTROY: _ensure_player("BlockDestroyPlayer"),
+        EVENT_ENEMY_CRUSH: _ensure_player("EnemyCrushPlayer"),
+        EVENT_POWER_UP: _ensure_player("PowerUpPlayer"),
+        EVENT_GAME_OVER: _ensure_player("GameOverPlayer"),
+    }
+    for player: AudioStreamPlayer in _players.values():
+        player.stream = null
+        player.autoplay = false
+        player.bus = "Master"
+        player.process_mode = Node.PROCESS_MODE_ALWAYS
+    var bgm_player := _players.get(EVENT_BGM, null)
+    if bgm_player and not bgm_player.finished.is_connected(_on_bgm_finished):
+        bgm_player.finished.connect(_on_bgm_finished)
+
+func _ensure_players_ready() -> void:
+    if _players.is_empty():
+        _initialize_players()
+
+func _on_bgm_finished() -> void:
+    var player: AudioStreamPlayer = _players.get(EVENT_BGM, null)
+    if player == null:
+        return
+    player.play()

--- a/scripts/core/GameManager.gd
+++ b/scripts/core/GameManager.gd
@@ -76,6 +76,9 @@ func set_lives(value: int) -> void:
     if _lives <= 0:
         _is_game_over = true
         game_over.emit()
+        var audio_manager := _get_audio_manager()
+        if audio_manager:
+            audio_manager.play_game_over()
 
 func start_level(level_name: String = "", level_file: String = "") -> void:
     """Propaga el inicio del nivel actual al HUD."""
@@ -95,6 +98,9 @@ func start_level(level_name: String = "", level_file: String = "") -> void:
         return
     _current_level_name = resolved_name
     level_started.emit(_current_level_name)
+    var audio_manager := _get_audio_manager()
+    if audio_manager:
+        audio_manager.play_bgm()
 
 func register_enemy(enemy: Enemy) -> void:
     """Añade enemigos activos para referencia rápida."""
@@ -108,6 +114,9 @@ func unregister_enemy(enemy: Enemy) -> void:
 func on_enemy_defeated(enemy: Enemy) -> void:
     """Elimina la referencia del enemigo y suma score."""
     _enemies.erase(enemy)
+    var audio_manager := _get_audio_manager()
+    if audio_manager:
+        audio_manager.play_enemy_crush()
     add_score(Consts.ENEMY_SCORE)
     if _enemies.is_empty():
         _handle_level_cleared()
@@ -137,6 +146,9 @@ func return_to_menu() -> void:
     lives_changed.emit(_lives)
     _high_score = HighScoreService.get_high_score_value()
     high_score_changed.emit(_high_score)
+    var audio_manager := _get_audio_manager()
+    if audio_manager:
+        audio_manager.stop_bgm()
     get_tree().change_scene_to_file(Consts.MAIN_MENU_SCENE_PATH)
 
 func get_player() -> Player:
@@ -241,3 +253,12 @@ func _refresh_high_score() -> void:
     """Sincroniza el valor del high score desde el servicio persistente."""
     _high_score = HighScoreService.get_high_score_value()
     high_score_changed.emit(_high_score)
+
+func _get_audio_manager() -> AudioManager:
+    var tree := get_tree()
+    if tree == null:
+        return null
+    var root := tree.root
+    if root == null:
+        return null
+    return root.get_node_or_null("AudioManager") as AudioManager

--- a/scripts/entities/Block.gd
+++ b/scripts/entities/Block.gd
@@ -60,6 +60,9 @@ func request_slide(direction: Vector2i) -> bool:
     _launch_direction = direction
     current_state = Enums.BlockState.LAUNCHED
     _play_launch_feedback()
+    var audio_manager := _get_audio_manager()
+    if audio_manager:
+        audio_manager.play_block_launch()
     return true
 
 
@@ -77,6 +80,9 @@ func destroy_block() -> void:
         return
     current_state = Enums.BlockState.DESTROYED
     _play_destroy_feedback()
+    var audio_manager := _get_audio_manager()
+    if audio_manager:
+        audio_manager.play_block_destroy()
     queue_free()
 
 
@@ -150,3 +156,12 @@ func _play_destroy_feedback() -> void:
         _feedback_tween.kill()
     _feedback_tween = create_tween()
     _feedback_tween.tween_property(self, "modulate:a", 0.0, SLIDE_TIME)
+
+func _get_audio_manager() -> AudioManager:
+    var tree := get_tree()
+    if tree == null:
+        return null
+    var root := tree.root
+    if root == null:
+        return null
+    return root.get_node_or_null("AudioManager") as AudioManager

--- a/scripts/entities/PowerUp.gd
+++ b/scripts/entities/PowerUp.gd
@@ -25,6 +25,9 @@ func collect() -> void:
     _collected = true
     var bonus: int = score_value if score_value > 0 else _resolve_score_from_type()
     collected.emit(self, bonus)
+    var audio_manager := _get_audio_manager()
+    if audio_manager:
+        audio_manager.play_power_up()
     _apply_score_bonus(bonus)
     queue_free()
 
@@ -45,3 +48,12 @@ func _apply_score_bonus(bonus: int) -> void:
     if bonus == 0:
         return
     GameManager.add_score(bonus)
+
+func _get_audio_manager() -> AudioManager:
+    var tree := get_tree()
+    if tree == null:
+        return null
+    var root := tree.root
+    if root == null:
+        return null
+    return root.get_node_or_null("AudioManager") as AudioManager

--- a/tests/integration/sandbox_audio_hooks.gd
+++ b/tests/integration/sandbox_audio_hooks.gd
@@ -1,0 +1,9 @@
+extends Node
+
+func _ready() -> void:
+    AudioManager.play_bgm()
+    AudioManager.play_block_launch()
+    AudioManager.play_block_destroy()
+    AudioManager.play_enemy_crush()
+    AudioManager.play_power_up()
+    AudioManager.play_game_over()

--- a/tests/integration/sandbox_audio_hooks.tscn
+++ b/tests/integration/sandbox_audio_hooks.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/integration/sandbox_audio_hooks.gd" id="1"]
+
+[node name="SandboxAudioHooks" type="Node"]
+script = ExtResource("1")

--- a/tests/unit/test_audio_hooks.gd
+++ b/tests/unit/test_audio_hooks.gd
@@ -1,0 +1,108 @@
+extends Node
+
+const BlockScene: PackedScene = preload("res://scenes/entities/Block.tscn")
+const PowerUpScene: PackedScene = preload("res://scenes/entities/PowerUp.tscn")
+const GameHelpers = preload("res://scripts/utils/helpers.gd")
+
+class MockAudioStreamPlayer:
+    extends AudioStreamPlayer
+    var play_count := 0
+    var stop_count := 0
+
+    func play(from_position: float = 0.0) -> void:
+        play_count += 1
+
+    func stop() -> void:
+        stop_count += 1
+
+func run_tests() -> Array:
+    return [
+        _test_bgm_triggers_on_level_start(),
+        _test_block_launch_triggers_audio(),
+        _test_block_destroy_triggers_audio(),
+        _test_enemy_crush_triggers_audio(),
+        _test_power_up_collect_triggers_audio(),
+        _test_game_over_triggers_audio(),
+    ]
+
+func _test_bgm_triggers_on_level_start() -> Dictionary:
+    var player := _override_player(AudioManager.EVENT_BGM)
+    GameManager.start_level("Audio Hook Stage", "")
+    return {
+        "name": "El inicio de nivel dispara el BGM",
+        "passed": player.play_count == 1,
+    }
+
+func _test_block_launch_triggers_audio() -> Dictionary:
+    var player := _override_player(AudioManager.EVENT_BLOCK_LAUNCH)
+    var previous_bounds := GameHelpers.get_map_bounds()
+    GameHelpers.set_map_bounds(Rect2i(Vector2i.ZERO, Vector2i(5, 5)))
+    var block: Block = BlockScene.instantiate()
+    add_child(block)
+    var start_grid := Vector2i(1, 2)
+    block.global_position = GameHelpers.grid_to_world(start_grid)
+    block.target_position = block.global_position
+    var launched := block.request_slide(Vector2i.RIGHT)
+    var result := {
+        "name": "El lanzamiento de bloques reproduce audio",
+        "passed": launched and player.play_count == 1,
+    }
+    block.queue_free()
+    GameHelpers.set_map_bounds(previous_bounds)
+    return result
+
+func _test_block_destroy_triggers_audio() -> Dictionary:
+    var player := _override_player(AudioManager.EVENT_BLOCK_DESTROY)
+    var block: Block = BlockScene.instantiate()
+    add_child(block)
+    block.global_position = Vector2.ZERO
+    block.target_position = block.global_position
+    block.destroy_block()
+    var result := {
+        "name": "La destrucción de bloques reproduce audio",
+        "passed": player.play_count == 1,
+    }
+    block.queue_free()
+    return result
+
+func _test_enemy_crush_triggers_audio() -> Dictionary:
+    var player := _override_player(AudioManager.EVENT_ENEMY_CRUSH)
+    var enemy := Enemy.new()
+    GameManager.on_enemy_defeated(enemy)
+    var result := {
+        "name": "Aplastar enemigos reproduce audio",
+        "passed": player.play_count == 1,
+    }
+    return result
+
+func _test_power_up_collect_triggers_audio() -> Dictionary:
+    var player := _override_player(AudioManager.EVENT_POWER_UP)
+    var power_up: PowerUp = PowerUpScene.instantiate()
+    add_child(power_up)
+    power_up.collect()
+    var result := {
+        "name": "Recoger power-up reproduce audio",
+        "passed": player.play_count == 1,
+    }
+    power_up.queue_free()
+    return result
+
+func _test_game_over_triggers_audio() -> Dictionary:
+    var player := _override_player(AudioManager.EVENT_GAME_OVER)
+    var previous_lives := GameManager.get("_lives")
+    var previous_game_over := GameManager.get("_is_game_over")
+    GameManager.set_lives(0)
+    var result := {
+        "name": "Game Over reproduce audio",
+        "passed": player.play_count == 1,
+    }
+    GameManager.set("_lives", previous_lives)
+    GameManager.set("_is_game_over", previous_game_over)
+    if previous_lives > 0:
+        GameManager.set_lives(previous_lives)
+    return result
+
+func _override_player(event_name: String) -> MockAudioStreamPlayer:
+    var mock := MockAudioStreamPlayer.new()
+    AudioManager.set_player_override(event_name, mock)
+    return mock


### PR DESCRIPTION
## Summary
- add an AudioManager autoload with placeholder AudioStreamPlayers for BGM and key SFX events
- trigger the new audio hooks from block actions, power-up pickup, and GameManager lifecycle updates
- provide unit and integration scaffolding plus documentation updates for the audio layer

## Testing
- not run (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd8fd53284833096f51211d8cb9c38