### PR TITLE
Fix AudioManager autoload class conflict

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -21,7 +21,7 @@
 - [x] Sistema de puntuación arcade y tabla de récords (High Score)
 - [x] Corrección de parseo JSON en HighScoreService
 - [x] Hooks de música y efectos de sonido (dummy)
-- [ ] Corrección de conflicto de AudioManager (autoload vs class_name) y variables mal tipadas
+- [x] Corrección de conflicto de AudioManager (autoload vs class_name) y variables mal tipadas
 - [ ] Animaciones retro (dummy)
 - [ ] Pantalla de introducción / attract mode
 - [ ] Balance y dificultad progresiva

--- a/scripts/core/AudioManager.gd
+++ b/scripts/core/AudioManager.gd
@@ -1,15 +1,15 @@
 ## AudioManager centraliza la reproducción de música y efectos de sonido.
 extends Node
-class_name AudioManager
+class_name AudioManagerService
 
-const EVENT_BGM := "bgm"
-const EVENT_BLOCK_LAUNCH := "block_launch"
-const EVENT_BLOCK_DESTROY := "block_destroy"
-const EVENT_ENEMY_CRUSH := "enemy_crush"
-const EVENT_POWER_UP := "power_up"
-const EVENT_GAME_OVER := "game_over"
+const EVENT_BGM := StringName("bgm")
+const EVENT_BLOCK_LAUNCH := StringName("block_launch")
+const EVENT_BLOCK_DESTROY := StringName("block_destroy")
+const EVENT_ENEMY_CRUSH := StringName("enemy_crush")
+const EVENT_POWER_UP := StringName("power_up")
+const EVENT_GAME_OVER := StringName("game_over")
 
-var _players: Dictionary = {}
+var _players: Dictionary[StringName, AudioStreamPlayer] = {}
 
 func _ready() -> void:
     """Crea los nodos de audio necesarios para los distintos eventos."""
@@ -59,7 +59,7 @@ func play_game_over() -> void:
     _ensure_players_ready()
     _restart_player(EVENT_GAME_OVER)
 
-func set_player_override(event_name: String, player: AudioStreamPlayer) -> void:
+func set_player_override(event_name: StringName, player: AudioStreamPlayer) -> void:
     """Permite sustituir un reproductor para pruebas o configuraciones especiales."""
     _ensure_players_ready()
     if not _players.has(event_name):
@@ -67,17 +67,17 @@ func set_player_override(event_name: String, player: AudioStreamPlayer) -> void:
     var current: AudioStreamPlayer = _players[event_name]
     if is_instance_valid(current):
         current.queue_free()
-    var target_name := current.name if current else StringName(event_name + "_player")
+    var target_name := current.name if current else StringName(String(event_name) + "_player")
     player.name = target_name
     add_child(player)
     _players[event_name] = player
 
-func get_player(event_name: String) -> AudioStreamPlayer:
+func get_player(event_name: StringName) -> AudioStreamPlayer:
     """Devuelve el reproductor asociado a un evento."""
     _ensure_players_ready()
     return _players.get(event_name, null)
 
-func _restart_player(event_name: String) -> void:
+func _restart_player(event_name: StringName) -> void:
     var player: AudioStreamPlayer = _players.get(event_name, null)
     if player == null:
         return

--- a/scripts/core/GameManager.gd
+++ b/scripts/core/GameManager.gd
@@ -254,11 +254,11 @@ func _refresh_high_score() -> void:
     _high_score = HighScoreService.get_high_score_value()
     high_score_changed.emit(_high_score)
 
-func _get_audio_manager() -> AudioManager:
+func _get_audio_manager() -> AudioManagerService:
     var tree := get_tree()
     if tree == null:
         return null
     var root := tree.root
     if root == null:
         return null
-    return root.get_node_or_null("AudioManager") as AudioManager
+    return root.get_node_or_null("AudioManager") as AudioManagerService

--- a/scripts/entities/Block.gd
+++ b/scripts/entities/Block.gd
@@ -157,11 +157,11 @@ func _play_destroy_feedback() -> void:
     _feedback_tween = create_tween()
     _feedback_tween.tween_property(self, "modulate:a", 0.0, SLIDE_TIME)
 
-func _get_audio_manager() -> AudioManager:
+func _get_audio_manager() -> AudioManagerService:
     var tree := get_tree()
     if tree == null:
         return null
     var root := tree.root
     if root == null:
         return null
-    return root.get_node_or_null("AudioManager") as AudioManager
+    return root.get_node_or_null("AudioManager") as AudioManagerService

--- a/scripts/entities/PowerUp.gd
+++ b/scripts/entities/PowerUp.gd
@@ -49,11 +49,11 @@ func _apply_score_bonus(bonus: int) -> void:
         return
     GameManager.add_score(bonus)
 
-func _get_audio_manager() -> AudioManager:
+func _get_audio_manager() -> AudioManagerService:
     var tree := get_tree()
     if tree == null:
         return null
     var root := tree.root
     if root == null:
         return null
-    return root.get_node_or_null("AudioManager") as AudioManager
+    return root.get_node_or_null("AudioManager") as AudioManagerService

--- a/tests/unit/test_audio_hooks.gd
+++ b/tests/unit/test_audio_hooks.gd
@@ -102,7 +102,7 @@ func _test_game_over_triggers_audio() -> Dictionary:
         GameManager.set_lives(previous_lives)
     return result
 
-func _override_player(event_name: String) -> MockAudioStreamPlayer:
+func _override_player(event_name: StringName) -> MockAudioStreamPlayer:
     var mock := MockAudioStreamPlayer.new()
     AudioManager.set_player_override(event_name, mock)
     return mock


### PR DESCRIPTION
## Summary
- rename the AudioManager script class to AudioManagerService so it no longer collides with the autoload name
- strongly type audio event identifiers and update game logic helpers to request the singleton with the new class
- adjust the audio unit test helper and task checklist to reflect the fix

## Testing
- not run (no automated suite available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddb647502c83308ba04dc3aa2abc14