### PR TITLE
Fix level camera centering and window stretch settings

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,7 @@ AudioManager="*res://scripts/core/AudioManager.gd"
 window/size/viewport_width=640
 window/size/viewport_height=480
 window/stretch/mode="2d"
+window/stretch/aspect="keep"
 
 [dotnet]
 

--- a/scenes/core/Level.tscn
+++ b/scenes/core/Level.tscn
@@ -16,6 +16,7 @@ script = ExtResource("1")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 unique_name_in_owner = true
+current = true
 
 [node name="NonPlayableBackground" type="ColorRect" parent="."]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- configure the window stretch aspect to keep the 640x480 viewport ratio
- mark the level camera as current so the helper-based zoom and centering are applied at runtime

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddc13310f483309fa22da34ae238e6