### PR TITLE
Configure window aspect and resolution

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -25,7 +25,7 @@
 - [x] Corrección de escalado y centrado visual del área jugable
 - [x] Corrección de escalado y centrado visual en Camera2D
 - [x] Separación de HUD en CanvasLayer para evitar deformación por zoom
-- [ ] Ajuste de configuración de ventana (stretch/mode=2d, aspect=keep, size=640x480)
+- [x] Ajuste de configuración de ventana (stretch/mode=2d, aspect=keep, size=640x480)
 - [ ] Animaciones retro (dummy)
 - [ ] Pantalla de introducción / attract mode
 - [ ] Balance y dificultad progresiva

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,8 @@ AudioManager="*res://scripts/core/AudioManager.gd"
 
 [display]
 
+window/size/width=640
+window/size/height=480
 window/size/viewport_width=640
 window/size/viewport_height=480
 window/stretch/mode="2d"


### PR DESCRIPTION
## Summary
- configure the project window stretch to 2D with a 640x480 base resolution
- mark the window configuration task as completed in the checklist

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dddbb241a88330b7b10a44ebef3992